### PR TITLE
fix: set display name during create

### DIFF
--- a/integration/user-test/main.tf
+++ b/integration/user-test/main.tf
@@ -25,7 +25,6 @@ resource "coderd_user" "ethan2" {
   username = "${data.coderd_user.ethan.username}2"
   name = "${data.coderd_user.ethan.name}2"
   email = "${data.coderd_user.ethan.email}.au"
-  login_type = "${data.coderd_user.ethan.login_type}"
   roles = data.coderd_user.ethan.roles
   suspended = data.coderd_user.ethan.suspended
 }


### PR DESCRIPTION
Display name is optional on a `coderd_user` resource, but we never set it during `Create`, and Terraform requires that all computed fields be known after a `Create`.

Also provides a better error message for when a password is required but not supplied.