### PR TITLE
chore: add uuid terraform type

### DIFF
--- a/internal/provider/uuid.go
+++ b/internal/provider/uuid.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type uuidType struct {
+	basetypes.StringType
+}
+
+var _ basetypes.StringTypable = UUIDType
+
+var UUIDType = uuidType{}
+
+// String implements basetypes.StringTypable.
+func (t uuidType) String() string {
+	return "UUID"
+}
+
+func (t uuidType) ValueType(ctx context.Context) attr.Value {
+	return UUID{}
+}
+
+// Equal implements basetypes.StringTypable.
+func (t uuidType) Equal(o attr.Type) bool {
+	if o, ok := o.(uuidType); ok {
+		return t.StringType.Equal(o.StringType)
+	}
+	return false
+}
+
+// ValueFromString implements basetypes.StringTypable.
+func (t uuidType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewUUIDNull(), diags
+	}
+	if in.IsUnknown() {
+		return NewUUIDUnknown(), diags
+	}
+
+	value, err := uuid.Parse(in.ValueString())
+	if err != nil {
+		// The framework doesn't want us to return validation errors here
+		// for some reason. They get caught by `ValidateAttribute` instead,
+		// and this function isn't called directly by our provider - UUIDValue
+		// takes a valid UUID instead of a string.
+		return NewUUIDUnknown(), diags
+	}
+
+	return UUIDValue(value), diags
+}
+
+// ValueFromTerraform implements basetypes.StringTypable.
+func (t uuidType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T, expected basetypes.StringValue", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+type UUID struct {
+	// The framework requires custom types extend a primitive or object.
+	basetypes.StringValue
+	value uuid.UUID
+}
+
+var (
+	_ basetypes.StringValuable    = UUID{}
+	_ xattr.ValidateableAttribute = UUID{}
+)
+
+func NewUUIDNull() UUID {
+	return UUID{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+func NewUUIDUnknown() UUID {
+	return UUID{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+func UUIDValue(value uuid.UUID) UUID {
+	return UUID{
+		StringValue: basetypes.NewStringValue(value.String()),
+		value:       value,
+	}
+}
+
+// Equal implements basetypes.StringValuable.
+func (v UUID) Equal(o attr.Value) bool {
+	if o, ok := o.(UUID); ok {
+		return v.StringValue.Equal(o.StringValue)
+	}
+	return false
+}
+
+// Type implements basetypes.StringValuable.
+func (v UUID) Type(context.Context) attr.Type {
+	return UUIDType
+}
+
+// ValueUUID returns the UUID value. If the value is null or unknown, returns the Nil UUID.
+func (v UUID) ValueUUID() uuid.UUID {
+	return v.value
+}
+
+// ValidateAttribute implements xattr.ValidateableAttribute.
+func (v UUID) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsNull() || v.IsUnknown() {
+		return
+	}
+
+	if _, err := uuid.Parse(v.ValueString()); err != nil {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid UUID",
+			"The provided value cannot be parsed as a UUID\n\n"+
+				"Path: "+req.Path.String()+"\n"+
+				"Error: "+err.Error(),
+		)
+	}
+}

--- a/internal/provider/uuid_internal_test.go
+++ b/internal/provider/uuid_internal_test.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+)
+
+var ValidUUID = uuid.New()
+
+func TestUUIDTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    tftypes.Value
+		expected attr.Value
+	}{
+		{
+			name:     "null",
+			input:    tftypes.NewValue(tftypes.String, nil),
+			expected: NewUUIDNull(),
+		},
+		{
+			name:     "unknown",
+			input:    tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expected: NewUUIDUnknown(),
+		},
+		{
+			name:     "valid UUID",
+			input:    tftypes.NewValue(tftypes.String, ValidUUID.String()),
+			expected: UUIDValue(ValidUUID),
+		},
+		{
+			name:     "invalid UUID",
+			input:    tftypes.NewValue(tftypes.String, "invalid"),
+			expected: NewUUIDUnknown(),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			actual, err := uuidType.ValueFromTerraform(UUIDType, ctx, test.input)
+			require.NoError(t, err)
+
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestUUIDToStringValue(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		uuid     UUID
+		expected types.String
+	}{
+		"value": {
+			uuid:     UUIDValue(ValidUUID),
+			expected: types.StringValue(ValidUUID.String()),
+		},
+		"null": {
+			uuid:     NewUUIDNull(),
+			expected: types.StringNull(),
+		},
+		"unknown": {
+			uuid:     NewUUIDUnknown(),
+			expected: types.StringUnknown(),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			s, _ := test.uuid.ToStringValue(ctx)
+
+			require.Equal(t, test.expected, s)
+		})
+	}
+}


### PR DESCRIPTION
Closes #36.

This ended up being mostly boilerplate, and is very similar to examples in [Hashicorp's own providers](https://github.com/hashicorp/terraform-provider-awscc/tree/main/internal/types) (which is licensed such that we can use it as a base).