### PR TITLE
fix: support non-enterprise template resources

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -23,7 +23,7 @@ A group on the Coder deployment. If you want to have a group resource with unman
 
 - `avatar_url` (String) The URL of the group's avatar.
 - `display_name` (String) The display name of the group. Defaults to the group name.
-- `members` (Set of String) Members of the group, by ID. If null, members will not be added or removed.
+- `members` (Set of String) Members of the group, by ID. If null, members will not be added or removed by Terraform.
 - `organization_id` (String) The organization ID that the group belongs to. Defaults to the provider default organization ID.
 - `quota_allowance` (Number) The number of quota credits to allocate to each user in the group.
 

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -17,12 +17,12 @@ A Coder template
 
 ### Required
 
-- `acl` (Attributes) Access control list for the template. (see [below for nested schema](#nestedatt--acl))
 - `name` (String) The name of the template.
 - `versions` (Attributes List) (see [below for nested schema](#nestedatt--versions))
 
 ### Optional
 
+- `acl` (Attributes) Access control list for the template. Requires an enterprise Coder deployment. If null, ACL policies will not be added or removed by Terraform. (see [below for nested schema](#nestedatt--acl))
 - `allow_user_auto_start` (Boolean)
 - `allow_user_auto_stop` (Boolean)
 - `description` (String) A description of the template.
@@ -33,33 +33,6 @@ A Coder template
 ### Read-Only
 
 - `id` (String) The ID of the template.
-
-<a id="nestedatt--acl"></a>
-### Nested Schema for `acl`
-
-Required:
-
-- `groups` (Attributes Set) (see [below for nested schema](#nestedatt--acl--groups))
-- `users` (Attributes Set) (see [below for nested schema](#nestedatt--acl--users))
-
-<a id="nestedatt--acl--groups"></a>
-### Nested Schema for `acl.groups`
-
-Required:
-
-- `id` (String)
-- `role` (String)
-
-
-<a id="nestedatt--acl--users"></a>
-### Nested Schema for `acl.users`
-
-Required:
-
-- `id` (String)
-- `role` (String)
-
-
 
 <a id="nestedatt--versions"></a>
 ### Nested Schema for `versions`
@@ -97,3 +70,30 @@ Required:
 
 - `name` (String)
 - `value` (String)
+
+
+
+<a id="nestedatt--acl"></a>
+### Nested Schema for `acl`
+
+Required:
+
+- `groups` (Attributes Set) (see [below for nested schema](#nestedatt--acl--groups))
+- `users` (Attributes Set) (see [below for nested schema](#nestedatt--acl--users))
+
+<a id="nestedatt--acl--groups"></a>
+### Nested Schema for `acl.groups`
+
+Required:
+
+- `id` (String)
+- `role` (String)
+
+
+<a id="nestedatt--acl--users"></a>
+### Nested Schema for `acl.users`
+
+Required:
+
+- `id` (String)
+- `role` (String)

--- a/internal/provider/group_data_source.go
+++ b/internal/provider/group_data_source.go
@@ -174,8 +174,10 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		data.OrganizationID = UUIDValue(d.data.DefaultOrganizationID)
 	}
 
-	var group codersdk.Group
-	var err error
+	var (
+		group codersdk.Group
+		err   error
+	)
 	if !data.ID.IsNull() {
 		groupID := data.ID.ValueUUID()
 		group, err = client.Group(ctx, groupID)

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -93,7 +93,7 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				},
 			},
 			"members": schema.SetAttribute{
-				MarkdownDescription: "Members of the group, by ID. If null, members will not be added or removed.",
+				MarkdownDescription: "Members of the group, by ID. If null, members will not be added or removed by Terraform.",
 				ElementType:         UUIDType,
 				Optional:            true,
 			},

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -115,8 +115,10 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	client := d.data.Client
 
-	var org codersdk.Organization
-	var err error
+	var (
+		org codersdk.Organization
+		err error
+	)
 	if !data.ID.IsNull() { // By ID
 		orgID := data.ID.ValueUUID()
 		org, err = client.Organization(ctx, orgID)


### PR DESCRIPTION
The ACL attribute on templates was previously required, making it impossible to create managed templates for an unlicensed Coder deployment. 
Now, when the attribute is `null`, Terraform will not attempt to read or update the template's ACL.