### PR TITLE
fix: template version replacement & metadata updates

### DIFF
--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -24,8 +24,8 @@ A Coder template
 
 - `acl` (Attributes) Access control list for the template. Requires an enterprise Coder deployment. If null, ACL policies will not be added or removed by Terraform. (see [below for nested schema](#nestedatt--acl))
 - `activity_bump_ms` (Number) The activity bump duration for all workspaces created from this template, in milliseconds. Defaults to one hour.
-- `allow_user_auto_start` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true.
-- `allow_user_auto_stop` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true.
+- `allow_user_auto_start` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true. Requires an enterprise Coder deployment.
+- `allow_user_auto_stop` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true. Requires an enterprise Coder deployment.
 - `allow_user_cancel_workspace_jobs` (Boolean) Whether users can cancel in-progress workspace jobs using this template. Defaults to true.
 - `auto_start_permitted_days_of_week` (Set of String) List of days of the week in which autostart is allowed to happen, for all workspaces created from this template. Defaults to all days. If no days are specified, autostart is not allowed. Requires an enterprise Coder deployment.
 - `auto_stop_requirement` (Attributes) The auto-stop requirement for all workspaces created from this template. Requires an enterprise Coder deployment. (see [below for nested schema](#nestedatt--auto_stop_requirement))
@@ -55,7 +55,7 @@ Optional:
 
 - `active` (Boolean) Whether this version is the active version of the template. Only one version can be active at a time.
 - `message` (String) A message describing the changes in this version of the template. Messages longer than 72 characters will be truncated.
-- `name` (String) The name of the template version. Automatically generated if not provided.
+- `name` (String) The name of the template version. Automatically generated if not provided. If provided, the name *must* change each time the directory contents are updated.
 - `provisioner_tags` (Attributes Set) Provisioner tags for the template version. (see [below for nested schema](#nestedatt--versions--provisioner_tags))
 - `tf_vars` (Attributes Set) Terraform variables for the template version. (see [below for nested schema](#nestedatt--versions--tf_vars))
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
+	github.com/otiai10/copy v1.14.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,10 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
+github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
+github.com/otiai10/mint v1.5.1/go.mod h1:MJm72SBthJjz8qhefc4z1PYEieWmy8Bku7CjcAqyUSM=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/integration/template-test/main.tf
+++ b/integration/template-test/main.tf
@@ -7,10 +7,15 @@ terraform {
   }
 }
 
+provider "coderd" {
+  url   = "http://localhost:3000"
+  token = "NbRNSwdzeb-Npwlm9TIOX3bpEQIsgt2KI"
+}
+
 resource "coderd_user" "ethan" {
-  username   = "ethan"
-  name       = "Ethan Coolguy"
-  email      = "test@coder.com"
+  username   = "dean"
+  name       = "Dean Coolguy"
+  email      = "deantest@coder.com"
   roles      = ["owner", "template-admin"]
   login_type = "password"
   password   = "SomeSecurePassword!"
@@ -41,8 +46,7 @@ resource "coderd_template" "sample" {
   }
   versions = [
     {
-      name      = "latest"
-      directory = "./example-template"
+      directory = "./example-template-2"
       active    = true
       tf_vars = [
         {
@@ -52,7 +56,6 @@ resource "coderd_template" "sample" {
       ]
     },
     {
-      name      = "legacy"
       directory = "./example-template-2"
       active    = false
       tf_vars = [

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 	"slices"
@@ -9,10 +10,15 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	cp "github.com/otiai10/copy"
+	"github.com/stretchr/testify/require"
+
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAccTemplateResource(t *testing.T) {
@@ -23,198 +29,348 @@ func TestAccTemplateResource(t *testing.T) {
 	client := integration.StartCoder(ctx, t, "template_acc", true)
 	firstUser, err := client.User(ctx, codersdk.Me)
 	require.NoError(t, err)
-	cfg1 := testAccTemplateResourceConfig{
-		URL:   client.URL.String(),
-		Token: client.SessionToken(),
-		Name:  PtrTo("example-template"),
-		Versions: []testAccTemplateVersionConfig{
-			{
-				Name:      PtrTo("main"),
-				Directory: PtrTo("../../integration/template-test/example-template/"),
-				Active:    PtrTo(true),
-				// TODO(ethanndickson): Remove this when we add in `*.tfvars` parsing
-				TerraformVariables: []testAccTemplateKeyValueConfig{
-					{
-						Key:   PtrTo("name"),
-						Value: PtrTo("world"),
+
+	exTemplateOne := t.TempDir()
+	err = cp.Copy("../../integration/template-test/example-template", exTemplateOne)
+	require.NoError(t, err)
+
+	exTemplateTwo := t.TempDir()
+	err = cp.Copy("../../integration/template-test/example-template-2", exTemplateTwo)
+	require.NoError(t, err)
+
+	t.Run("BasicUsage", func(t *testing.T) {
+		cfg1 := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  PtrTo("example-template"),
+			Versions: []testAccTemplateVersionConfig{
+				{
+					// Auto-generated version name
+					Directory: &exTemplateOne,
+					Active:    PtrTo(true),
+					// TODO(ethanndickson): Remove this when we add in `*.tfvars` parsing
+					TerraformVariables: []testAccTemplateKeyValueConfig{
+						{
+							Key:   PtrTo("name"),
+							Value: PtrTo("world"),
+						},
 					},
 				},
 			},
-		},
-		ACL: testAccTemplateACLConfig{
-			GroupACL: []testAccTemplateKeyValueConfig{
-				{
-					Key:   PtrTo(firstUser.OrganizationIDs[0].String()),
-					Value: PtrTo("use"),
+			ACL: testAccTemplateACLConfig{
+				GroupACL: []testAccTemplateKeyValueConfig{
+					{
+						Key:   PtrTo(firstUser.OrganizationIDs[0].String()),
+						Value: PtrTo("use"),
+					},
 				},
 			},
-		},
-	}
+		}
 
-	cfg2 := cfg1
-	cfg2.Versions = slices.Clone(cfg2.Versions)
-	cfg2.Name = PtrTo("example-template-new")
-	cfg2.AllowUserAutostart = PtrTo(false)
-	cfg2.Versions[0].Directory = PtrTo("../../integration/template-test/example-template-2/")
-	cfg2.Versions[0].Name = PtrTo("new")
-	cfg2.ACL.UserACL = []testAccTemplateKeyValueConfig{
-		{
-			Key:   PtrTo(firstUser.ID.String()),
-			Value: PtrTo("admin"),
-		},
-	}
-	cfg2.AutostopRequirement = testAccAutostopRequirementConfig{
-		DaysOfWeek: PtrTo([]string{"monday", "tuesday"}),
-		Weeks:      PtrTo(int64(2)),
-	}
-
-	cfg3 := cfg2
-	cfg3.Versions = slices.Clone(cfg3.Versions)
-	cfg3.Versions = append(cfg3.Versions, testAccTemplateVersionConfig{
-		Name:      PtrTo("legacy-template"),
-		Directory: PtrTo("../../integration/template-test/example-template/"),
-		Active:    PtrTo(false),
-		TerraformVariables: []testAccTemplateKeyValueConfig{
+		cfg2 := cfg1
+		cfg2.Versions = slices.Clone(cfg2.Versions)
+		cfg2.Name = PtrTo("example-template-new")
+		cfg2.AllowUserAutostart = PtrTo(false)
+		cfg2.Versions[0].Directory = &exTemplateTwo
+		cfg2.Versions[0].Name = PtrTo("new")
+		cfg2.ACL.UserACL = []testAccTemplateKeyValueConfig{
 			{
-				Key:   PtrTo("name"),
-				Value: PtrTo("world"),
+				Key:   PtrTo(firstUser.ID.String()),
+				Value: PtrTo("admin"),
 			},
-		},
+		}
+		cfg2.AutostopRequirement = testAccAutostopRequirementConfig{
+			DaysOfWeek: PtrTo([]string{"monday", "tuesday"}),
+			Weeks:      PtrTo(int64(2)),
+		}
+
+		cfg3 := cfg2
+		cfg3.Versions = slices.Clone(cfg3.Versions)
+		cfg3.Versions = append(cfg3.Versions, testAccTemplateVersionConfig{
+			Name:      PtrTo("legacy-template"),
+			Directory: &exTemplateOne,
+			Active:    PtrTo(false),
+			TerraformVariables: []testAccTemplateKeyValueConfig{
+				{
+					Key:   PtrTo("name"),
+					Value: PtrTo("world"),
+				},
+			},
+		})
+
+		cfg4 := cfg3
+		cfg4.Versions = slices.Clone(cfg4.Versions)
+		cfg4.Versions[0].Active = PtrTo(false)
+		cfg4.Versions[1].Active = PtrTo(true)
+
+		cfg5 := cfg4
+		cfg5.Versions = slices.Clone(cfg5.Versions)
+		cfg5.Versions[0], cfg5.Versions[1] = cfg5.Versions[1], cfg5.Versions[0]
+
+		cfg6 := cfg4
+		cfg6.Versions = slices.Clone(cfg6.Versions[1:])
+
+		cfg7 := cfg6
+		cfg7.ACL.null = true
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Init, creates the first version
+				{
+					Config: cfg1.String(t),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("coderd_template.test", "id"),
+						resource.TestCheckResourceAttr("coderd_template.test", "display_name", "example-template"),
+						resource.TestCheckResourceAttr("coderd_template.test", "description", ""),
+						resource.TestCheckResourceAttr("coderd_template.test", "organization_id", firstUser.OrganizationIDs[0].String()),
+						resource.TestCheckResourceAttr("coderd_template.test", "icon", ""),
+						resource.TestCheckResourceAttr("coderd_template.test", "default_ttl_ms", "0"),
+						resource.TestCheckResourceAttr("coderd_template.test", "activity_bump_ms", "3600000"),
+						resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.days_of_week.#", "0"),
+						resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.weeks", "1"),
+						resource.TestCheckResourceAttr("coderd_template.test", "auto_start_permitted_days_of_week.#", "7"),
+						resource.TestCheckResourceAttr("coderd_template.test", "allow_user_cancel_workspace_jobs", "true"),
+						resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_start", "true"),
+						resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_stop", "true"),
+						resource.TestCheckResourceAttr("coderd_template.test", "failure_ttl_ms", "0"),
+						resource.TestCheckResourceAttr("coderd_template.test", "time_til_dormant_ms", "0"),
+						resource.TestCheckResourceAttr("coderd_template.test", "time_til_dormant_autodelete_ms", "0"),
+						resource.TestCheckResourceAttr("coderd_template.test", "require_active_version", "false"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"name":           regexp.MustCompile(".+"),
+							"id":             regexp.MustCompile(".+"),
+							"directory_hash": regexp.MustCompile(".+"),
+							"message":        regexp.MustCompile(""),
+						}),
+						testAccCheckNumTemplateVersions(ctx, client, 1),
+					),
+				},
+				// Modify template contents. Creates a second version.
+				{
+					Config: cfg1.String(t),
+					PreConfig: func() {
+						file := fmt.Sprintf("%s/terraform.tfvars", *cfg1.Versions[0].Directory)
+						newFile := []byte("name = \"world2\"")
+						err := os.WriteFile(file, newFile, 0644)
+						require.NoError(t, err)
+					},
+					Check: testAccCheckNumTemplateVersions(ctx, client, 2),
+					// Version should be updated, checked at the end
+				},
+				// Undo modification. Creates a third version since it differs from the last apply
+				{
+					Config: cfg1.String(t),
+					PreConfig: func() {
+						file := fmt.Sprintf("%s/terraform.tfvars", *cfg1.Versions[0].Directory)
+						newFile := []byte("name = \"world\"")
+						err := os.WriteFile(file, newFile, 0644)
+						require.NoError(t, err)
+					},
+					Check: testAccCheckNumTemplateVersions(ctx, client, 3),
+				},
+				// Import
+				{
+					Config:            cfg1.String(t),
+					ResourceName:      "coderd_template.test",
+					ImportState:       true,
+					ImportStateVerify: true,
+					// In the real world, `versions` needs to be added to the configuration after importing
+					// We can't import ACL as we can't currently differentiate between managed and unmanaged ACL
+					ImportStateVerifyIgnore: []string{"versions", "acl"},
+				},
+				// Change existing version directory & name, update template metadata. Creates a fourth version.
+				{
+					Config: cfg2.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("coderd_template.test", "id"),
+						resource.TestCheckResourceAttr("coderd_template.test", "name", "example-template-new"),
+						resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_start", "false"),
+						resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.days_of_week.#", "2"),
+						resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.weeks", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"name": regexp.MustCompile("new"),
+						}),
+						testAccCheckNumTemplateVersions(ctx, client, 4),
+					),
+				},
+				// Append version. Creates a fifth version
+				{
+					Config: cfg3.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"name": regexp.MustCompile("legacy-template"),
+						}),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"name": regexp.MustCompile("new"),
+						}),
+						testAccCheckNumTemplateVersions(ctx, client, 5),
+					),
+				},
+				// Change active version
+				{
+					Config: cfg4.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("true"),
+							"name":   regexp.MustCompile("legacy-template"),
+						}),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("false"),
+							"name":   regexp.MustCompile("new"),
+						}),
+					),
+				},
+				// Swap versions in-place
+				{
+					Config: cfg5.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("true"),
+							"name":   regexp.MustCompile("legacy-template"),
+						}),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("false"),
+							"name":   regexp.MustCompile("new"),
+						}),
+					),
+				},
+				// Delete version at index 0
+				{
+					Config: cfg6.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("true"),
+							"name":   regexp.MustCompile("legacy-template"),
+						}),
+					),
+				},
+				// Unmanaged ACL
+				{
+					Config: cfg7.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr("coderd_template.test", "acl"),
+						testAccCheckNumTemplateVersions(ctx, client, 5),
+					),
+				},
+				// Resource deleted
+			},
+		})
 	})
 
-	cfg4 := cfg3
-	cfg4.Versions = slices.Clone(cfg4.Versions)
-	cfg4.Versions[0].Active = PtrTo(false)
-	cfg4.Versions[1].Active = PtrTo(true)
+	t.Run("IdenticalVersions", func(t *testing.T) {
+		cfg1 := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  PtrTo("example-template2"),
+			Versions: []testAccTemplateVersionConfig{
+				{
+					// Auto-generated version name
+					Directory: PtrTo("../../integration/template-test/example-template-2/"),
+					TerraformVariables: []testAccTemplateKeyValueConfig{
+						{
+							Key:   PtrTo("name"),
+							Value: PtrTo("world"),
+						},
+					},
+					Active: PtrTo(true),
+				},
+				{
+					// Auto-generated version name
+					Directory: PtrTo("../../integration/template-test/example-template-2/"),
+					TerraformVariables: []testAccTemplateKeyValueConfig{
+						{
+							Key:   PtrTo("name"),
+							Value: PtrTo("world"),
+						},
+					},
+				},
+			},
+		}
 
-	cfg5 := cfg4
-	cfg5.Versions = slices.Clone(cfg5.Versions)
-	cfg5.Versions[0], cfg5.Versions[1] = cfg5.Versions[1], cfg5.Versions[0]
+		cfg2 := cfg1
+		cfg2.Versions = slices.Clone(cfg2.Versions)
+		cfg2.Versions[1].Name = PtrTo("new-name")
 
-	cfg6 := cfg4
-	cfg6.Versions = slices.Clone(cfg6.Versions[1:])
+		cfg3 := cfg2
+		cfg3.Versions = slices.Clone(cfg3.Versions)
+		cfg3.Versions[0].Name = PtrTo("new-name-one")
+		cfg3.Versions[1].Name = PtrTo("new-name-two")
+		cfg3.Versions[0], cfg3.Versions[1] = cfg3.Versions[1], cfg3.Versions[0]
 
-	cfg7 := cfg6
-	cfg7.ACL.null = true
+		cfg4 := cfg1
+		cfg4.Versions = slices.Clone(cfg4.Versions)
+		cfg4.Versions[0].Directory = PtrTo("../../integration/template-test/example-template/")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		IsUnitTest:               true,
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: cfg1.String(t),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("coderd_template.test", "id"),
-					resource.TestCheckResourceAttr("coderd_template.test", "display_name", "example-template"),
-					resource.TestCheckResourceAttr("coderd_template.test", "description", ""),
-					resource.TestCheckResourceAttr("coderd_template.test", "organization_id", firstUser.OrganizationIDs[0].String()),
-					resource.TestCheckResourceAttr("coderd_template.test", "icon", ""),
-					resource.TestCheckResourceAttr("coderd_template.test", "default_ttl_ms", "0"),
-					resource.TestCheckResourceAttr("coderd_template.test", "activity_bump_ms", "3600000"),
-					resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.days_of_week.#", "0"),
-					resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.weeks", "1"),
-					resource.TestCheckResourceAttr("coderd_template.test", "auto_start_permitted_days_of_week.#", "7"),
-					resource.TestCheckResourceAttr("coderd_template.test", "allow_user_cancel_workspace_jobs", "true"),
-					resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_start", "true"),
-					resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_stop", "true"),
-					resource.TestCheckResourceAttr("coderd_template.test", "failure_ttl_ms", "0"),
-					resource.TestCheckResourceAttr("coderd_template.test", "time_til_dormant_ms", "0"),
-					resource.TestCheckResourceAttr("coderd_template.test", "time_til_dormant_autodelete_ms", "0"),
-					resource.TestCheckResourceAttr("coderd_template.test", "require_active_version", "false"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"name":           regexp.MustCompile("main"),
-						"id":             regexp.MustCompile(".*"),
-						"directory_hash": regexp.MustCompile(".+"),
-						"message":        regexp.MustCompile(""),
-					}),
-				),
+		cfg5 := cfg4
+		cfg5.Versions = slices.Clone(cfg5.Versions)
+		cfg5.Versions[1].Directory = PtrTo("../../integration/template-test/example-template/")
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Create two identical versions
+				{
+					Config: cfg1.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccCheckNumTemplateVersions(ctx, client, 2),
+					),
+				},
+				// Change the name of the second version
+				{
+					Config: cfg2.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("true"),
+							"name":   regexp.MustCompile(".+"),
+						}),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("false"),
+							"name":   regexp.MustCompile("^new-name$"),
+						}),
+					),
+				},
+				// Swap the two versions, give them both new names
+				{
+					Config: cfg3.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("true"),
+							"name":   regexp.MustCompile("^new-name-one$"),
+						}),
+						resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+							"active": regexp.MustCompile("false"),
+							"name":   regexp.MustCompile("^new-name-two$"),
+						}),
+						testAccCheckNumTemplateVersions(ctx, client, 2),
+					),
+				},
+				// Change the first version's contents
+				{
+					Config: cfg4.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccCheckNumTemplateVersions(ctx, client, 3),
+					),
+				},
+				// Change the second version's contents to match the first
+				{
+					Config: cfg5.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						testAccCheckNumTemplateVersions(ctx, client, 4),
+					),
+				},
 			},
-			// Import
-			{
-				Config:            cfg1.String(t),
-				ResourceName:      "coderd_template.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// In the real world, `versions` needs to be added to the configuration after importing
-				ImportStateVerifyIgnore: []string{"versions", "acl"},
-			},
-			// Update existing version & metadata
-			{
-				Config: cfg2.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("coderd_template.test", "id"),
-					resource.TestCheckResourceAttr("coderd_template.test", "name", "example-template-new"),
-					resource.TestCheckResourceAttr("coderd_template.test", "allow_user_auto_start", "false"),
-					resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.days_of_week.#", "2"),
-					resource.TestCheckResourceAttr("coderd_template.test", "auto_stop_requirement.weeks", "2"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"name": regexp.MustCompile("new"),
-					}),
-				),
-			},
-			// Append version
-			{
-				Config: cfg3.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"name": regexp.MustCompile("legacy-template"),
-					}),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"name": regexp.MustCompile("new"),
-					}),
-				),
-			},
-			// Change active version
-			{
-				Config: cfg4.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"active": regexp.MustCompile("true"),
-						"name":   regexp.MustCompile("legacy-template"),
-					}),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"active": regexp.MustCompile("false"),
-						"name":   regexp.MustCompile("new"),
-					}),
-				),
-			},
-			// Swap versions
-			{
-				Config: cfg5.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "2"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"active": regexp.MustCompile("true"),
-						"name":   regexp.MustCompile("legacy-template"),
-					}),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"active": regexp.MustCompile("false"),
-						"name":   regexp.MustCompile("new"),
-					}),
-				),
-			},
-			// Delete version at index 0
-			{
-				Config: cfg6.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
-					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
-						"active": regexp.MustCompile("true"),
-						"name":   regexp.MustCompile("legacy-template"),
-					}),
-				),
-			},
-			// Unmanaged ACL
-			{
-				Config: cfg7.String(t),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("coderd_template.test", "acl"),
-				),
-			},
-		},
+		})
 	})
 }
 
@@ -394,4 +550,195 @@ type testAccTemplateVersionConfig struct {
 type testAccTemplateKeyValueConfig struct {
 	Key   *string
 	Value *string
+}
+
+func testAccCheckNumTemplateVersions(ctx context.Context, client *codersdk.Client, expected int) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		templates, err := client.Templates(ctx)
+		if err != nil {
+			return err
+		}
+		if len(templates) != 1 {
+			return fmt.Errorf("expected 1 template, got %d", len(templates))
+		}
+		versions, err := client.TemplateVersionsByTemplate(ctx, codersdk.TemplateVersionsByTemplateRequest{
+			TemplateID: templates[0].ID,
+		})
+		if err != nil {
+			return err
+		}
+		if len(versions) != expected {
+			return fmt.Errorf("expected %d versions, got %d", expected, len(versions))
+		}
+		return nil
+	}
+}
+
+func TestReconcileVersionIDs(t *testing.T) {
+	aUUID := uuid.New()
+	bUUID := uuid.New()
+	cases := []struct {
+		Name             string
+		inputVersions    Versions
+		inputState       LastVersionsByHash
+		expectedVersions Versions
+	}{
+		{
+			Name: "IdenticalDontRename",
+			inputVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:   aUUID,
+						Name: "bar",
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(aUUID),
+				},
+			},
+		},
+		{
+			Name: "IdenticalRenameFirst",
+			inputVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:   aUUID,
+						Name: "baz",
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(aUUID),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+		},
+		{
+			Name: "IdenticalHashesInState",
+			inputVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:   aUUID,
+						Name: "qux",
+					},
+					{
+						ID:   bUUID,
+						Name: "baz",
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(aUUID),
+				},
+				{
+					Name:          types.StringValue("bar"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(bUUID),
+				},
+			},
+		},
+		{
+			Name: "UnknownUsesStateInOrder",
+			inputVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+				{
+					Name:          types.StringUnknown(),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:   aUUID,
+						Name: "qux",
+					},
+					{
+						ID:   bUUID,
+						Name: "baz",
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("foo"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(aUUID),
+				},
+				{
+					Name:          types.StringValue("baz"),
+					DirectoryHash: types.StringValue("aaa"),
+					ID:            UUIDValue(bUUID),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			c.inputVersions.reconcileVersionIDs(c.inputState)
+			require.Equal(t, c.expectedVersions, c.inputVersions)
+		})
+
+	}
 }


### PR DESCRIPTION
To avoid spurious template version diffs, the template resource will only create a new template version under specific circumstances.
1. When creating the resource, a template version will be created for each in the list.
2. Subsequent `terraform apply`s will hash the contents of the given directories. The provider will then check if the hash belongs to a template version known of in the previous apply.
    - If the hash doesn't belong to any, a new template version will be created
    - If the hash belongs to a previous template version, but the names are different, the name will be updated.
    - If the hash belongs to a previous template version, and the name is the same (or both auto-generated names), no update will happen.
    
Therefore, the `version` `name` field should only be set when it's guaranteed that it will be updated whenever the contents of the supplied directory change (such as setting it to the current git commit short-hash). Most users will likely want to use the auto-generated names anyway.

Of note, is that we can determine whether or not a new template version will be created during `terraform plan`.

During `plan`, we only compare against the last known versions to handle the case where a user reverts the template to one used multiple `apply`s prior (such when as undoing a change). 
If we stored all the hashes of all previous versions, undoing a change like this would not create a new template version in the list, and would instead be a no-op, or only update the name of an older version, which is likely confusing behaviour.
