### PR TITLE
fix: validate resources against available features before creating

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -3,12 +3,12 @@
 page_title: "coderd_group Resource - terraform-provider-coderd"
 subcategory: ""
 description: |-
-  A group on the Coder deployment. If you want to have a group resource with unmanaged members, but still want to read the members in Terraform, use the data.coderd_group data source.
+  A group on the Coder deployment. If you want to have a group resource with unmanaged members, but still want to read the members in Terraform, use the data.coderd_group data source. Creating groups requires an Enterprise license.
 ---
 
 # coderd_group (Resource)
 
-A group on the Coder deployment. If you want to have a group resource with unmanaged members, but still want to read the members in Terraform, use the `data.coderd_group` data source.
+A group on the Coder deployment. If you want to have a group resource with unmanaged members, but still want to read the members in Terraform, use the `data.coderd_group` data source. Creating groups requires an Enterprise license.
 
 
 

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -22,23 +22,23 @@ A Coder template
 
 ### Optional
 
-- `acl` (Attributes) Access control list for the template. Requires an enterprise Coder deployment. If null, ACL policies will not be added or removed by Terraform. (see [below for nested schema](#nestedatt--acl))
+- `acl` (Attributes) (Enterprise) Access control list for the template. If null, ACL policies will not be added or removed by Terraform. (see [below for nested schema](#nestedatt--acl))
 - `activity_bump_ms` (Number) The activity bump duration for all workspaces created from this template, in milliseconds. Defaults to one hour.
-- `allow_user_auto_start` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true. Requires an enterprise Coder deployment.
-- `allow_user_auto_stop` (Boolean) Whether users can auto-start workspaces created from this template. Defaults to true. Requires an enterprise Coder deployment.
+- `allow_user_auto_start` (Boolean) (Enterprise) Whether users can auto-start workspaces created from this template. Defaults to true.
+- `allow_user_auto_stop` (Boolean) (Enterprise) Whether users can auto-start workspaces created from this template. Defaults to true.
 - `allow_user_cancel_workspace_jobs` (Boolean) Whether users can cancel in-progress workspace jobs using this template. Defaults to true.
-- `auto_start_permitted_days_of_week` (Set of String) List of days of the week in which autostart is allowed to happen, for all workspaces created from this template. Defaults to all days. If no days are specified, autostart is not allowed. Requires an enterprise Coder deployment.
-- `auto_stop_requirement` (Attributes) The auto-stop requirement for all workspaces created from this template. Requires an enterprise Coder deployment. (see [below for nested schema](#nestedatt--auto_stop_requirement))
+- `auto_start_permitted_days_of_week` (Set of String) (Enterprise) List of days of the week in which autostart is allowed to happen, for all workspaces created from this template. Defaults to all days. If no days are specified, autostart is not allowed.
+- `auto_stop_requirement` (Attributes) (Enterprise) The auto-stop requirement for all workspaces created from this template. (see [below for nested schema](#nestedatt--auto_stop_requirement))
 - `default_ttl_ms` (Number) The default time-to-live for all workspaces created from this template, in milliseconds.
 - `deprecation_message` (String) If set, the template will be marked as deprecated and users will be blocked from creating new workspaces from it.
 - `description` (String) A description of the template.
 - `display_name` (String) The display name of the template. Defaults to the template name.
-- `failure_ttl_ms` (Number) The max lifetime before Coder stops all resources for failed workspaces created from this template, in milliseconds.
+- `failure_ttl_ms` (Number) (Enterprise) The max lifetime before Coder stops all resources for failed workspaces created from this template, in milliseconds.
 - `icon` (String) Relative path or external URL that specifes an icon to be displayed in the dashboard.
 - `organization_id` (String) The ID of the organization. Defaults to the provider's default organization
-- `require_active_version` (Boolean) Whether workspaces must be created from the active version of this template. Defaults to false.
-- `time_til_dormant_autodelete_ms` (Number) The max lifetime before Coder permanently deletes dormant workspaces created from this template.
-- `time_til_dormant_ms` (Number) The max lifetime before Coder locks inactive workspaces created from this template, in milliseconds.
+- `require_active_version` (Boolean) (Enterprise) Whether workspaces must be created from the active version of this template. Defaults to false.
+- `time_til_dormant_autodelete_ms` (Number) (Enterprise) The max lifetime before Coder permanently deletes dormant workspaces created from this template.
+- `time_til_dormant_ms` (Number) Enterprise) The max lifetime before Coder locks inactive workspaces created from this template, in milliseconds.
 
 ### Read-Only
 

--- a/internal/provider/group_data_source.go
+++ b/internal/provider/group_data_source.go
@@ -168,6 +168,11 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
+	resp.Diagnostics.Append(CheckGroupEntitlements(ctx, d.data.Features)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	client := d.data.Client
 
 	if data.OrganizationID.IsNull() {

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -19,7 +19,7 @@ func TestAccOrganizationDataSource(t *testing.T) {
 		t.Skip("Acceptance tests are disabled.")
 	}
 	ctx := context.Background()
-	client := integration.StartCoder(ctx, t, "org_data_acc", true)
+	client := integration.StartCoder(ctx, t, "org_data_acc", false)
 	firstUser, err := client.User(ctx, codersdk.Me)
 	require.NoError(t, err)
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,6 +34,7 @@ type CoderdProvider struct {
 type CoderdProviderData struct {
 	Client                *codersdk.Client
 	DefaultOrganizationID uuid.UUID
+	Features              map[codersdk.FeatureName]codersdk.Feature
 }
 
 // CoderdProviderModel describes the provider data model.
@@ -111,9 +112,15 @@ func (p *CoderdProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		}
 		data.DefaultOrganizationID = UUIDValue(user.OrganizationIDs[0])
 	}
+	entitlements, err := client.Entitlements(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", "failed to get deployment entitlements: "+err.Error())
+	}
+
 	providerData := &CoderdProviderData{
 		Client:                client,
 		DefaultOrganizationID: data.DefaultOrganizationID.ValueUUID(),
+		Features:              entitlements.Features,
 	}
 	resp.DataSourceData = providerData
 	resp.ResourceData = providerData

--- a/internal/provider/workspace_proxy_resource.go
+++ b/internal/provider/workspace_proxy_resource.go
@@ -103,6 +103,11 @@ func (r *WorkspaceProxyResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	if !r.data.Features[codersdk.FeatureWorkspaceProxy].Enabled {
+		resp.Diagnostics.AddError("Feature not enabled", "Your license is not entitled to create workspace proxies.")
+		return
+	}
+
 	client := r.data.Client
 	wsp, err := client.CreateWorkspaceProxy(ctx, codersdk.CreateWorkspaceProxyRequest{
 		Name:        data.Name.ValueString(),

--- a/internal/provider/workspace_proxy_resource_test.go
+++ b/internal/provider/workspace_proxy_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"text/template"
@@ -51,6 +52,35 @@ func TestAccWorkspaceProxyResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccWorkspaceProxyResourceAGPL(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests are disabled.")
+	}
+	ctx := context.Background()
+	client := integration.StartCoder(ctx, t, "ws_proxy_acc", false)
+
+	cfg1 := testAccWorkspaceProxyResourceConfig{
+		URL:         client.URL.String(),
+		Token:       client.SessionToken(),
+		Name:        PtrTo("example"),
+		DisplayName: PtrTo("Example WS Proxy"),
+		Icon:        PtrTo("/emojis/1f407.png"),
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg1.String(t),
+				ExpectError: regexp.MustCompile("Your license is not entitled to create workspace proxies."),
+			},
+		},
+	})
+
 }
 
 type testAccWorkspaceProxyResourceConfig struct {


### PR DESCRIPTION
Closes #61 

We can't actually validate the fields during the plan, as we don't have access to the provider data store (with the `*codersdk.Client`) during plan modification, or validation. 
Instead we do it during `Create` for enterprise-only resources, and `Create` and `Update` for templates.