### PR TITLE
fix: always use config name for new template versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6
-	github.com/coder/coder/v2 v2.14.0
+	github.com/coder/coder/v2 v2.14.1
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/coder/coder/v2 v2.14.0 h1:Z7iyLdnFHYh57xddSCS2IE5JDy0O6r957T4S9lt5Obo=
 github.com/coder/coder/v2 v2.14.0/go.mod h1:dO79BI5XlP8rrtne1JpRcVehe27bNMXdZKyn1NsWbjA=
+github.com/coder/coder/v2 v2.14.1 h1:tSYe7H4pNRL8hh9ynwHK7QYTOvG5hcuZJEOkn4ZPASE=
+github.com/coder/coder/v2 v2.14.1/go.mod h1:dO79BI5XlP8rrtne1JpRcVehe27bNMXdZKyn1NsWbjA=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/serpent v0.7.0 h1:zGpD2GlF3lKIVkMjNGKbkip88qzd5r/TRcc30X/SrT0=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -128,7 +128,6 @@ func TestIntegration(t *testing.T) {
 				})
 				require.NoError(t, err)
 				require.Len(t, versions, 2)
-				require.Equal(t, "latest", versions[0].Name)
 				require.NotEmpty(t, versions[0].ID)
 				require.Equal(t, templates[0].ID, *versions[0].TemplateID)
 				require.Equal(t, templates[0].ActiveVersionID, versions[0].ID)

--- a/integration/template-test/main.tf
+++ b/integration/template-test/main.tf
@@ -7,15 +7,10 @@ terraform {
   }
 }
 
-provider "coderd" {
-  url   = "http://localhost:3000"
-  token = "NbRNSwdzeb-Npwlm9TIOX3bpEQIsgt2KI"
-}
-
 resource "coderd_user" "ethan" {
-  username   = "dean"
-  name       = "Dean Coolguy"
-  email      = "deantest@coder.com"
+  username   = "ethan"
+  name       = "Ethan Coolguy"
+  email      = "test@coder.com"
   roles      = ["owner", "template-admin"]
   login_type = "password"
   password   = "SomeSecurePassword!"

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -579,13 +579,14 @@ func TestReconcileVersionIDs(t *testing.T) {
 	bUUID := uuid.New()
 	cases := []struct {
 		Name             string
-		inputVersions    Versions
+		planVersions     Versions
+		configVersions   Versions
 		inputState       LastVersionsByHash
 		expectedVersions Versions
 	}{
 		{
 			Name: "IdenticalDontRename",
-			inputVersions: []TemplateVersion{
+			planVersions: []TemplateVersion{
 				{
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
@@ -595,6 +596,14 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("bar"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            NewUUIDUnknown(),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+				{
+					Name: types.StringValue("bar"),
 				},
 			},
 			inputState: map[string][]PreviousTemplateVersion{
@@ -620,7 +629,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 		},
 		{
 			Name: "IdenticalRenameFirst",
-			inputVersions: []TemplateVersion{
+			planVersions: []TemplateVersion{
 				{
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
@@ -630,6 +639,14 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("bar"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            NewUUIDUnknown(),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+				{
+					Name: types.StringValue("bar"),
 				},
 			},
 			inputState: map[string][]PreviousTemplateVersion{
@@ -655,7 +672,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 		},
 		{
 			Name: "IdenticalHashesInState",
-			inputVersions: []TemplateVersion{
+			planVersions: []TemplateVersion{
 				{
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
@@ -665,6 +682,14 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("bar"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            NewUUIDUnknown(),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+				{
+					Name: types.StringValue("bar"),
 				},
 			},
 			inputState: map[string][]PreviousTemplateVersion{
@@ -694,7 +719,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 		},
 		{
 			Name: "UnknownUsesStateInOrder",
-			inputVersions: []TemplateVersion{
+			planVersions: []TemplateVersion{
 				{
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
@@ -704,6 +729,14 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringUnknown(),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            NewUUIDUnknown(),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+				{
+					Name: types.StringValue("bar"),
 				},
 			},
 			inputState: map[string][]PreviousTemplateVersion{
@@ -731,13 +764,43 @@ func TestReconcileVersionIDs(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "NewVersionNewRandomName",
+			planVersions: []TemplateVersion{
+				{
+					Name:          types.StringValue("weird_draught12"),
+					DirectoryHash: types.StringValue("bbb"),
+					ID:            UUIDValue(aUUID),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringNull(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:   aUUID,
+						Name: "weird_draught12",
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:          types.StringUnknown(),
+					DirectoryHash: types.StringValue("bbb"),
+					ID:            NewUUIDUnknown(),
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
 		c := c
 		t.Run(c.Name, func(t *testing.T) {
-			c.inputVersions.reconcileVersionIDs(c.inputState)
-			require.Equal(t, c.expectedVersions, c.inputVersions)
+			c.planVersions.reconcileVersionIDs(c.inputState, c.configVersions)
+			require.Equal(t, c.expectedVersions, c.planVersions)
 		})
 
 	}


### PR DESCRIPTION
This bug would have been caught by the acceptance tests, had they not been run with the in-memory database. 
Added a unit test for this very same edge case.

Also patches Coder to `v2.14.1`, and adds the correct group name default of the empty string, to be consistent with the web GUI.