### PR TITLE
chore: run enterprise tests using license

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
               uses: crazy-max/ghaction-import-gpg@v6.1.0
               with:
                 gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-                passphrase: ${{ secrets.GPG_PASSPHRASE }}
             - name: Run GoReleaser
               uses: goreleaser/goreleaser-action@v6.0.0
               with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
       - run: go mod download
       - env:
           TF_ACC: "1"
+          CODER_ENTERPRISE_LICENSE: ${{ secrets.CODER_ENTERPRISE_LICENSE }}
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10
 

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -18,7 +18,6 @@ func TestAccGroupResource(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Acceptance tests are disabled.")
 	}
-
 	ctx := context.Background()
 	client := integration.StartCoder(ctx, t, "group_acc", true)
 	firstUser, err := client.User(ctx, codersdk.Me)


### PR DESCRIPTION
This splits all the acceptance tests that use enterprise features into separate tests, and only runs them if `CODER_ENTERPRISE_LICENSE` is set. Integration tests are only run using the license, for ease.

Requires `CODER_ENTERPRISE_LICENSE` be added to the repo secrets before merging.
