### PR TITLE
fix: fix minimum coder version warning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,13 @@ page_title: "coderd Provider"
 subcategory: ""
 description: |-
   ~> Warning
-  This provider is only compatible with Coder version 2.10.1 https://github.com/coder/coder/releases/tag/v2.13.0 and later.
+  This provider is only compatible with Coder version 2.13.0 https://github.com/coder/coder/releases/tag/v2.13.0 and later.
 ---
 
 # coderd Provider
 
 ~> **Warning**
-This provider is only compatible with Coder version [2.10.1](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
+This provider is only compatible with Coder version [2.13.0](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,13 @@ page_title: "coderd Provider"
 subcategory: ""
 description: |-
   ~> Warning
-  This provider is only compatible with Coder version 2.13.0 https://github.com/coder/coder/releases/tag/v2.13.0 and later.
+  This provider is only compatible with Coder version 2.10.1 https://github.com/coder/coder/releases/tag/v2.10.1 and later.
 ---
 
 # coderd Provider
 
 ~> **Warning**
-This provider is only compatible with Coder version [2.13.0](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
+This provider is only compatible with Coder version [2.10.1](https://github.com/coder/coder/releases/tag/v2.10.1) and later.
 
 
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -166,7 +166,7 @@ func TestIntegration(t *testing.T) {
 			tfCmd.Stderr = &buf
 			tt.preF(t, client)
 			if err := tfCmd.Run(); !assert.NoError(t, err) {
-				t.Logf(buf.String())
+				t.Logf("%s", buf.String())
 				t.FailNow()
 			}
 			tt.assertF(t, client)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func (p *CoderdProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `
 ~> **Warning**
-This provider is only compatible with Coder version [2.13.0](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
+This provider is only compatible with Coder version [2.10.1](https://github.com/coder/coder/releases/tag/v2.10.1) and later.
 `,
 		Attributes: map[string]schema.Attribute{
 			"url": schema.StringAttribute{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,7 +54,7 @@ func (p *CoderdProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `
 ~> **Warning**
-This provider is only compatible with Coder version [2.10.1](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
+This provider is only compatible with Coder version [2.13.0](https://github.com/coder/coder/releases/tag/v2.13.0) and later.
 `,
 		Attributes: map[string]schema.Attribute{
 			"url": schema.StringAttribute{


### PR DESCRIPTION
It was incorrectly linked to 2.13.0. 