### PR TITLE
docs: fix missing required attribute in example

### DIFF
--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -47,6 +47,7 @@ resource "coderd_template" "ubuntu-main" {
       id   = coderd_user.coder1.id
       role = "admin"
     }]
+    groups = []
   }
 }
 ```

--- a/examples/resources/coderd_template/resource.tf
+++ b/examples/resources/coderd_template/resource.tf
@@ -32,5 +32,6 @@ resource "coderd_template" "ubuntu-main" {
       id   = coderd_user.coder1.id
       role = "admin"
     }]
+    groups = []
   }
 }


### PR DESCRIPTION
Otherwise it might not be immediately obvious how to make a private template.