### PR TITLE
chore: support importing resources by fully qualified names

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   A group on the Coder deployment.
   Creating groups requires an Enterprise license.
+  When importing, the ID supplied can be either a group UUID retrieved via the API or <organization-name>/<group-name>.
 ---
 
 # coderd_group (Resource)
@@ -12,6 +13,8 @@ description: |-
 A group on the Coder deployment.
 
 Creating groups requires an Enterprise license.
+
+When importing, the ID supplied can be either a group UUID retrieved via the API or `<organization-name>/<group-name>`.
 
 ## Example Usage
 

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   A Coder template.
   Logs from building template versions are streamed from the provisioner when the TF_LOG environment variable is INFO or higher.
+  When importing, the ID supplied can be either a template UUID retrieved via the API or <organization-name>/<template-name>.
 ---
 
 # coderd_template (Resource)
@@ -12,6 +13,8 @@ description: |-
 A Coder template.
 
 Logs from building template versions are streamed from the provisioner when the `TF_LOG` environment variable is `INFO` or higher.
+
+When importing, the ID supplied can be either a template UUID retrieved via the API or `<organization-name>/<template-name>`.
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -4,11 +4,14 @@ page_title: "coderd_user Resource - terraform-provider-coderd"
 subcategory: ""
 description: |-
   A user on the Coder deployment.
+  When importing, the ID supplied can be either a user UUID or a username.
 ---
 
 # coderd_user (Resource)
 
 A user on the Coder deployment.
+
+When importing, the ID supplied can be either a user UUID or a username.
 
 ## Example Usage
 

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -78,11 +78,18 @@ func TestAccGroupResource(t *testing.T) {
 						resource.TestCheckResourceAttr("coderd_group.test", "members.0", user1.ID.String()),
 					),
 				},
-				// Import
+				// Import by ID
 				{
-					Config:                  cfg1.String(t),
 					ResourceName:            "coderd_group.test",
 					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"members"},
+				},
+				// Import by org name and group name
+				{
+					ResourceName:            "coderd_group.test",
+					ImportState:             true,
+					ImportStateId:           "default/example-group",
 					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"members"},
 				},

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -145,7 +145,7 @@ func TestAccTemplateResource(t *testing.T) {
 					},
 					Check: testAccCheckNumTemplateVersions(ctx, client, 3),
 				},
-				// Import
+				// Import by ID
 				{
 					Config:            cfg1.String(t),
 					ResourceName:      "coderd_template.test",
@@ -153,6 +153,14 @@ func TestAccTemplateResource(t *testing.T) {
 					ImportStateVerify: true,
 					// In the real world, `versions` needs to be added to the configuration after importing
 					// We can't import ACL as we can't currently differentiate between managed and unmanaged ACL
+					ImportStateVerifyIgnore: []string{"versions", "acl"},
+				},
+				// Import by org name and template name
+				{
+					ResourceName:            "coderd_template.test",
+					ImportState:             true,
+					ImportStateVerify:       true,
+					ImportStateId:           "default/example-template",
 					ImportStateVerifyIgnore: []string{"versions", "acl"},
 				},
 				// Change existing version directory & name, update template metadata. Creates a fourth version.

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -60,11 +60,20 @@ func TestAccUserResource(t *testing.T) {
 					resource.TestCheckResourceAttr("coderd_user.test", "suspended", "false"),
 				),
 			},
-			// ImportState testing
+			// Import by ID
 			{
 				ResourceName:      "coderd_user.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// We can't pull the password from the API.
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			// ImportState by username
+			{
+				ResourceName:      "coderd_user.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "example",
 				// We can't pull the password from the API.
 				ImportStateVerifyIgnore: []string{"password"},
 			},


### PR DESCRIPTION
Previously, user, group and template resources could only be imported via their UUIDs. The `coder/coder` frontend doesn't expose these UUIDs to the user, so we should provide an alternative, more user-friendly way to import resources.

User resources: ID or username, since usernames must be unique, even across multiple orgs.
Template resources: ID or `<organization-name>/<template-name>`
Group resources: ID or `<organization-name/<group-name>`