### PR TITLE
chore: validate fields as per coderd

### DIFF
--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -77,13 +77,18 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The unique name of the group.",
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 36),
+					stringvalidator.RegexMatches(nameValidRegex, "Group names must be alpahnumeric with hyphens."),
+				},
 			},
 			"display_name": schema.StringAttribute{
 				MarkdownDescription: "The display name of the group. Defaults to the group name.",
 				Computed:            true,
 				Optional:            true,
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
+					stringvalidator.LengthBetween(1, 64),
+					stringvalidator.RegexMatches(displayNameRegex, "Group display names must be alphanumeric with spaces"),
 				},
 				Default: stringdefault.StaticString(""),
 			},

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -248,12 +248,17 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 32),
+					stringvalidator.RegexMatches(nameValidRegex, "Template names must be alphanumeric with hyphens."),
 				},
 			},
 			"display_name": schema.StringAttribute{
 				MarkdownDescription: "The display name of the template. Defaults to the template name.",
 				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 64),
+					stringvalidator.RegexMatches(displayNameRegex, "Template display names must be alphanumeric with spaces."),
+				},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "A description of the template.",
@@ -394,7 +399,8 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 							Optional:            true,
 							Computed:            true,
 							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
+								stringvalidator.LengthBetween(1, 64),
+								stringvalidator.RegexMatches(templateVersionNameRegex, "Template version names must be alphanumeric with underscores and dots."),
 							},
 						},
 						"message": schema.StringAttribute{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -71,11 +71,18 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"username": schema.StringAttribute{
 				MarkdownDescription: "Username of the user.",
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 32),
+					stringvalidator.RegexMatches(nameValidRegex, "Username must be alphanumeric with hyphens."),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Display name of the user. Defaults to username.",
 				Computed:            true,
 				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 128),
+				},
 			},
 			"email": schema.StringAttribute{
 				MarkdownDescription: "Email address of the user.",

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -6,8 +6,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/google/uuid"
+)
+
+var (
+	nameValidRegex           = regexp.MustCompile("^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$")
+	templateVersionNameRegex = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[_.-]{1}[a-zA-Z0-9]+)*$`)
+	displayNameRegex         = regexp.MustCompile(`^[^\s](.*[^\s])?$`)
 )
 
 func PtrTo[T any](v T) *T {


### PR DESCRIPTION
Unfortunately, `coderd` validation errors don't return the reason why the validation failed, leading to confusing (almost useless) error messages when creating templates, groups or users with invalid names via the provider. 

The changes on `coderd/httpapi` to resolve this are non-trivial, as the [struct validation library](https://pkg.go.dev/github.com/go-playground/validator/v10) we use doesn't appear to support attaching an error reason to a field validator function.

Instead, we'll translate the string validation functions and regex from `coderd/httpapi/name.go`.