### PR TITLE
Improve markdown for attribute descriptions

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -58,7 +58,7 @@ resource "coderd_template" "example" {
 - `display_name` (String)
 - `members` (Attributes Set) Members of the group. (see [below for nested schema](#nestedatt--members))
 - `quota_allowance` (Number) The number of quota credits to allocate to each user in the group.
-- `source` (String) The source of the group. Either 'oidc' or 'user'.
+- `source` (String) The source of the group. Either `oidc` or `user`.
 
 <a id="nestedatt--members"></a>
 ### Nested Schema for `members`
@@ -69,7 +69,7 @@ Read-Only:
 - `email` (String)
 - `id` (String)
 - `last_seen_at` (Number) Unix timestamp of when the member was last seen.
-- `login_type` (String) The login type of the member. Can be 'oidc', 'token', 'password', 'github' or 'none'.
-- `status` (String) The status of the member. Can be 'active', 'dormant' or 'suspended'.
+- `login_type` (String) The login type of the member. Can be `oidc`, `token`, `password`, `github` or `none`.
+- `status` (String) The status of the member. Can be `active`, `dormant` or `suspended`.
 - `theme_preference` (String)
 - `username` (String)

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -48,9 +48,9 @@ resource "coderd_group" "bosses" {
 - `created_at` (Number) Unix timestamp of when the user was created.
 - `email` (String) Email of the user.
 - `last_seen_at` (Number) Unix timestamp of when the user was last seen.
-- `login_type` (String) Type of login for the user. Valid types are 'none', 'password', 'github', and 'oidc'.
+- `login_type` (String) Type of login for the user. Valid types are `none`, `password', `github`, and `oidc`.
 - `name` (String) Display name of the user.
 - `organization_ids` (Set of String) IDs of organizations the user is associated with.
-- `roles` (Set of String) Roles assigned to the user. Valid roles are 'owner', 'template-admin', 'user-admin', and 'auditor'.
+- `roles` (Set of String) Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`.
 - `suspended` (Boolean) Whether the user is suspended.
 - `theme_preference` (String) The user's preferred theme.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -55,7 +55,7 @@ resource "coderd_group" "group1" {
 
 - `avatar_url` (String) The URL of the group's avatar.
 - `display_name` (String) The display name of the group. Defaults to the group name.
-- `members` (Set of String) Members of the group, by ID. If null, members will not be added or removed by Terraform. To have a group resource with unmanaged members, but be able to read the members in Terraform, use `data.coderd_group`
+- `members` (Set of String) Members of the group, by ID. If `null`, members will not be added or removed by Terraform. To have a group resource with unmanaged members, but be able to read the members in Terraform, use `data.coderd_group`
 - `organization_id` (String) The organization ID that the group belongs to. Defaults to the provider default organization ID.
 - `quota_allowance` (Number) The number of quota credits to allocate to each user in the group.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -56,10 +56,10 @@ resource "coderd_user" "admin" {
 
 ### Optional
 
-- `login_type` (String) Type of login for the user. Valid types are 'none', 'password', 'github', and 'oidc'.
+- `login_type` (String) Type of login for the user. Valid types are `none`, `password`, `github`, and `oidc`.
 - `name` (String) Display name of the user. Defaults to username.
-- `password` (String, Sensitive) Password for the user. Required when login_type is 'password'. Passwords are saved into the state as plain text and should only be used for testing purposes.
-- `roles` (Set of String) Roles assigned to the user. Valid roles are 'owner', 'template-admin', 'user-admin', and 'auditor'.
+- `password` (String, Sensitive) Password for the user. Required when `login_type` is `password`. Passwords are saved into the state as plain text and should only be used for testing purposes.
+- `roles` (Set of String) Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`.
 - `suspended` (Boolean) Whether the user is suspended.
 
 ### Read-Only

--- a/docs/resources/workspace_proxy.md
+++ b/docs/resources/workspace_proxy.md
@@ -48,7 +48,7 @@ resource "kubernetes_deployment" "syd_wsproxy" {
 
 ### Required
 
-- `icon` (String) Relative path or external URL that specifes an icon to be displayed in the dashboard.
+- `icon` (String) Relative path or external URL that specifies an icon to be displayed in the dashboard.
 - `name` (String) Name of the workspace proxy.
 
 ### Optional

--- a/internal/provider/group_data_source.go
+++ b/internal/provider/group_data_source.go
@@ -93,7 +93,7 @@ func (d *GroupDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				Computed:            true,
 			},
 			"source": schema.StringAttribute{
-				MarkdownDescription: "The source of the group. Either 'oidc' or 'user'.",
+				MarkdownDescription: "The source of the group. Either `oidc` or `user`.",
 				Computed:            true,
 			},
 			"members": schema.SetNestedAttribute{
@@ -120,11 +120,11 @@ func (d *GroupDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							Computed:            true,
 						},
 						"status": schema.StringAttribute{
-							MarkdownDescription: "The status of the member. Can be 'active', 'dormant' or 'suspended'.",
+							MarkdownDescription: "The status of the member. Can be `active`, `dormant` or `suspended`.",
 							Computed:            true,
 						},
 						"login_type": schema.StringAttribute{
-							MarkdownDescription: "The login type of the member. Can be 'oidc', 'token', 'password', 'github' or 'none'.",
+							MarkdownDescription: "The login type of the member. Can be `oidc`, `token`, `password`, `github` or `none`.",
 							Computed:            true,
 						},
 						"theme_preference": schema.StringAttribute{

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -115,7 +115,7 @@ func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				},
 			},
 			"members": schema.SetAttribute{
-				MarkdownDescription: "Members of the group, by ID. If null, members will not be added or removed by Terraform. To have a group resource with unmanaged members, but be able to read the members in Terraform, use `data.coderd_group`",
+				MarkdownDescription: "Members of the group, by ID. If `null`, members will not be added or removed by Terraform. To have a group resource with unmanaged members, but be able to read the members in Terraform, use `data.coderd_group`",
 				ElementType:         UUIDType,
 				Optional:            true,
 			},

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -72,12 +72,12 @@ func (d *UserDataSource) Schema(ctx context.Context, req datasource.SchemaReques
 				Computed:            true,
 			},
 			"roles": schema.SetAttribute{
-				MarkdownDescription: "Roles assigned to the user. Valid roles are 'owner', 'template-admin', 'user-admin', and 'auditor'.",
+				MarkdownDescription: "Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`.",
 				Computed:            true,
 				ElementType:         types.StringType,
 			},
 			"login_type": schema.StringAttribute{
-				MarkdownDescription: "Type of login for the user. Valid types are 'none', 'password', 'github', and 'oidc'.",
+				MarkdownDescription: "Type of login for the user. Valid types are `none`, `password', `github`, and `oidc`.",
 				Computed:            true,
 			},
 			"suspended": schema.BoolAttribute{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -89,7 +89,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 			},
 			"roles": schema.SetAttribute{
-				MarkdownDescription: "Roles assigned to the user. Valid roles are 'owner', 'template-admin', 'user-admin', and 'auditor'.",
+				MarkdownDescription: "Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`.",
 				Computed:            true,
 				Optional:            true,
 				ElementType:         types.StringType,
@@ -101,7 +101,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Default: setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 			},
 			"login_type": schema.StringAttribute{
-				MarkdownDescription: "Type of login for the user. Valid types are 'none', 'password', 'github', and 'oidc'.",
+				MarkdownDescription: "Type of login for the user. Valid types are `none`, `password`, `github`, and `oidc`.",
 				Computed:            true,
 				Optional:            true,
 				Validators: []validator.String{
@@ -113,7 +113,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				},
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "Password for the user. Required when login_type is 'password'. Passwords are saved into the state as plain text and should only be used for testing purposes.",
+				MarkdownDescription: "Password for the user. Required when `login_type` is `password`. Passwords are saved into the state as plain text and should only be used for testing purposes.",
 				Optional:            true,
 				Sensitive:           true,
 			},

--- a/internal/provider/workspace_proxy_resource.go
+++ b/internal/provider/workspace_proxy_resource.go
@@ -60,7 +60,7 @@ func (r *WorkspaceProxyResource) Schema(ctx context.Context, req resource.Schema
 				Computed:            true,
 			},
 			"icon": schema.StringAttribute{
-				MarkdownDescription: "Relative path or external URL that specifes an icon to be displayed in the dashboard.",
+				MarkdownDescription: "Relative path or external URL that specifies an icon to be displayed in the dashboard.",
 				Required:            true,
 			},
 			"session_token": schema.StringAttribute{


### PR DESCRIPTION
- Ensure consistent usage of backticks for inline code.
- Fix a typo in the `icon` attribute description.