### PR TITLE
fix: use postgres for tests instead of dbmem

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -53,7 +53,6 @@ func StartCoder(ctx context.Context, t *testing.T, name string, useLicense bool)
 		Env: []string{
 			"CODER_HTTP_ADDRESS=0.0.0.0:3000",        // Listen on all interfaces inside the container
 			"CODER_ACCESS_URL=http://localhost:3000", // Set explicitly to avoid creating try.coder.app URLs.
-			"CODER_IN_MEMORY=true",                   // We don't necessarily care about real persistence here.
 			"CODER_TELEMETRY_ENABLE=false",           // Avoid creating noise.
 		},
 		Labels:       map[string]string{},


### PR DESCRIPTION
Our provider acceptance tests caught a very minor bug in `dbmem`, causing all CI to fail against the latest Coder image. 
Since nobody runs Coder using `dbmem`, It'd be better to test that the provider runs against the DB that people actually use. 

Running the acceptance tests on my dogfood workspace took ~140 seconds, up from ~80 using `dbmem` - but I think it's a fine tradeoff, and also means we don't need to modify our test suite to workaround the bug.

Treating this as a hotfix and merging.