### PR TITLE
fix: downgrade coder v2.15.0 -> 2.14.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	cdr.dev/slog v1.6.2-0.20240126064726-20367d4aede6
-	github.com/coder/coder/v2 v2.15.0
+	github.com/coder/coder/v2 v2.14.2
 	github.com/docker/docker v27.1.2+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/chenzhuoyu/iasm v0.9.0 h1:9fhXjVzq5hUy2gkhhgHl95zG2cEAhw9OSGs8toWWAwo
 github.com/chenzhuoyu/iasm v0.9.0/go.mod h1:Xjy2NpN3h7aUqeqM+woSuuvxmIe6+DDsiNLIrkAmYog=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/coder/coder/v2 v2.14.2 h1:RNNDDwjNK5D1XMQlK7LWrS4niVclkl1FXoaOaW7N5rs=
+github.com/coder/coder/v2 v2.14.2/go.mod h1:dO79BI5XlP8rrtne1JpRcVehe27bNMXdZKyn1NsWbjA=
 github.com/coder/coder/v2 v2.15.0 h1:tlJHTwc2Mx9NMCM6i4rlAMpxlFmkhN1cBAFFV6L5WtM=
 github.com/coder/coder/v2 v2.15.0/go.mod h1:3l5GBF/nx/aIUo20eKxLxazpFoTpyqgxbA4npjdg2JY=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=


### PR DESCRIPTION
I don't totally understand why CI tests passed (as goreleaser did not), but upgrading our codersdk `v2.15.0` introduced `coderdtest` as a dependency, when we want to avoid all the dependencies it requires, i.e. tailscale & gvisor, and the go mod replace directives for them.

 `codersdk` `v2.14.2` works fine against a `v2.15.0` deployment, so this is safe. When `v2.15.0` gets patched we'll upgrade once again.
 
 Related: https://github.com/coder/coder/pull/14633
 
 Treating as hotfix & merging.