### PR TITLE
chore: dump provisioner logs on error

### DIFF
--- a/internal/provider/template_data_source_test.go
+++ b/internal/provider/template_data_source_test.go
@@ -28,7 +28,7 @@ func TestAccTemplateDataSource(t *testing.T) {
 	require.NoError(t, err)
 	orgID := firstUser.OrganizationIDs[0]
 
-	version, err := newVersion(ctx, client, newVersionRequest{
+	version, err, _ := newVersion(ctx, client, newVersionRequest{
 		OrganizationID: orgID,
 		Version: &TemplateVersion{
 			Name:      types.StringValue("main"),


### PR DESCRIPTION
Closes #92.

Currently, the logs are only streamed to tflog and not dumped on failure. Now, if the provisioner build fails for any reason, the logs will be included in the final Terraform error, which, unlike tflog, is always shown.

```
│ Error: Provisioner Error
│ 
│   with coderd_template.sample,
│   on main.tf line 24, in resource "coderd_template" "sample":
│   24: resource "coderd_template" "sample" {
│ 
│ failed to wait for job: provisioner job did not succeed: failed (template
│ import provision for start: terraform plan: exit status 1)
│ 2024-09-12 03:14:05.029Z Initializing the backend...
│ 2024-09-12 03:14:05.029Z Initializing provider plugins...
│ 2024-09-12 03:14:05.029Z - Finding latest version of hashicorp/local...
│ 2024-09-12 03:14:05.687Z - Installing hashicorp/local v2.5.2...
│ 2024-09-12 03:14:05.930Z - Installed hashicorp/local v2.5.2 (signed by HashiCorp)
│ 2024-09-12 03:14:05.930Z Terraform has created a lock file .terraform.lock.hcl to record the provider
│ 2024-09-12 03:14:05.930Z selections it made above. Include this file in your version control repository
│ 2024-09-12 03:14:05.930Z so that Terraform can guarantee to make the same selections by default when
│ 2024-09-12 03:14:05.930Z you run "terraform init" in the future.
│ 2024-09-12 03:14:05.930Z Terraform has been successfully initialized!
│ 2024-09-12 03:14:05.930Z You may now begin working with Terraform. Try running "terraform plan" to see
│ 2024-09-12 03:14:05.930Z any changes that are required for your infrastructure. All Terraform commands
│ 2024-09-12 03:14:05.930Z should now work.
│ 2024-09-12 03:14:05.930Z If you ever set or change modules or backend configuration for Terraform,
│ 2024-09-12 03:14:05.930Z rerun this command to reinitialize your working directory. If you forget, other
│ 2024-09-12 03:14:05.930Z commands will detect it and remind you to do so if necessary.
│ 2024-09-12 03:14:05.963Z Terraform 1.9.2
│ 2024-09-12 03:14:06.026Z Error: Unsupported attribute
│ 2024-09-12 03:14:06.026Z on main.tf line 11, in output "a":
│ 2024-09-12 03:14:06.026Z   11:   value = local_file.a.content.asdf
│ 2024-09-12 03:14:06.026Z Can't access attributes on a primitive-typed value (string).
│ 
╵
```