### PR TITLE
fix: delete resources & data sources if not found

### DIFF
--- a/internal/provider/group_data_source.go
+++ b/internal/provider/group_data_source.go
@@ -187,6 +187,11 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		groupID := data.ID.ValueUUID()
 		group, err = client.Group(ctx, groupID)
 		if err != nil {
+			if isNotFound(err) {
+				resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Group with ID %s not found. Marking as deleted.", groupID.String()))
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get group by ID, got error: %s", err))
 			return
 		}
@@ -195,6 +200,11 @@ func (d *GroupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	} else {
 		group, err = client.GroupByOrgAndName(ctx, data.OrganizationID.ValueUUID(), data.Name.ValueString())
 		if err != nil {
+			if isNotFound(err) {
+				resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Group with name %s not found in organization with ID %s. Marking as deleted.", data.Name.ValueString(), data.OrganizationID.ValueString()))
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Failed to get group by name and org ID", err.Error())
 			return
 		}

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -220,6 +220,11 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	group, err := client.Group(ctx, groupID)
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Group with ID %s not found. Marking as deleted.", groupID.String()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get group, got error: %s", err))
 		return
 	}

--- a/internal/provider/license_resource.go
+++ b/internal/provider/license_resource.go
@@ -150,7 +150,9 @@ func (r *LicenseResource) Read(ctx context.Context, req resource.ReadRequest, re
 		}
 	}
 	if !found {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("License with ID %d not found", data.ID.ValueInt32()))
+		resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("License with ID %d not found. Marking as deleted.", data.ID.ValueInt32()))
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	// Save updated data into Terraform state

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -127,6 +127,11 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 		orgID := data.ID.ValueUUID()
 		org, err = client.Organization(ctx, orgID)
 		if err != nil {
+			if isNotFound(err) {
+				resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Organization with ID %s not found. Marking as deleted.", data.ID.ValueString()))
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get organization by ID, got error: %s", err))
 			return
 		}
@@ -137,6 +142,11 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 	} else if data.IsDefault.ValueBool() { // Get Default
 		org, err = client.OrganizationByName(ctx, "default")
 		if err != nil {
+			if isNotFound(err) {
+				resp.Diagnostics.AddWarning("Client Warning", "Default organization not found. Marking as deleted.")
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get default organization, got error: %s", err))
 			return
 		}
@@ -147,6 +157,11 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 	} else { // By Name
 		org, err = client.OrganizationByName(ctx, data.Name.ValueString())
 		if err != nil {
+			if isNotFound(err) {
+				resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Organization with name %s not found. Marking as deleted.", data.Name))
+				resp.State.RemoveResource(ctx)
+				return
+			}
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get organization by name, got error: %s", err))
 			return
 		}

--- a/internal/provider/template_data_source.go
+++ b/internal/provider/template_data_source.go
@@ -262,6 +262,11 @@ func (d *TemplateDataSource) Read(ctx context.Context, req datasource.ReadReques
 		template, err = client.TemplateByName(ctx, data.OrganizationID.ValueUUID(), data.Name.ValueString())
 	}
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", "Template not found. Marking as deleted.")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get template, got error: %s", err))
 		return
 	}

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -577,6 +577,11 @@ func (r *TemplateResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	template, err := client.Template(ctx, templateID)
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Template with ID %s not found. Marking as deleted.", templateID.String()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to get template: %s", err))
 		return
 	}

--- a/internal/provider/user_data_source.go
+++ b/internal/provider/user_data_source.go
@@ -149,6 +149,11 @@ func (d *UserDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 	user, err := client.User(ctx, ident)
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("User with identifier %q not found. Marking as deleted.", ident))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get current user, got error: %s", err))
 		return
 	}

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -251,6 +251,11 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	user, err := client.User(ctx, data.ID.ValueString())
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("User with ID %q not found. Marking as deleted.", data.ID.ValueString()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get current user, got error: %s", err))
 		return
 	}

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -3,11 +3,14 @@ package provider
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 
+	"github.com/coder/coder/v2/codersdk"
 	"github.com/google/uuid"
 )
 
@@ -112,4 +115,9 @@ func memberDiff(curMembers []uuid.UUID, plannedMembers []UUID) (add, remove []st
 		}
 	}
 	return add, remove
+}
+
+func isNotFound(err error) bool {
+	var sdkErr *codersdk.Error
+	return errors.As(err, &sdkErr) && sdkErr.StatusCode() == http.StatusNotFound
 }

--- a/internal/provider/workspace_proxy_resource.go
+++ b/internal/provider/workspace_proxy_resource.go
@@ -142,6 +142,11 @@ func (r *WorkspaceProxyResource) Read(ctx context.Context, req resource.ReadRequ
 	client := r.data.Client
 	wsp, err := client.WorkspaceProxyByID(ctx, data.ID.ValueUUID())
 	if err != nil {
+		if isNotFound(err) {
+			resp.Diagnostics.AddWarning("Client Warning", fmt.Sprintf("Workspace proxy with ID %s not found. Marking as deleted.", data.ID.ValueString()))
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to read workspace proxy: %v", err))
 		return
 	}


### PR DESCRIPTION
Closes #100.

Hashicorp's own providers only do this deletion if the resource can't be found during `Read`, and not during `Update`, so we'll do the same.