### PR TITLE
docs: replace example that requires TFC

### DIFF
--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -22,8 +22,8 @@ When importing, the ID supplied can be either a template UUID retrieved via the 
 // Provider populated from environment variables
 provider "coderd" {}
 
-// Get the commit SHA of the configuration's git repository
-variable "TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA" {
+// Can be populated using an environment variable, or an external datasource script
+variable "COMMIT_SHA" {
   type = string
 }
 
@@ -38,12 +38,12 @@ resource "coderd_template" "ubuntu-main" {
   description = "The main template for developing on Ubuntu."
   versions = [
     {
-      name        = "stable-${var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA}"
+      name        = "stable-${var.COMMIT_SHA}"
       description = "The stable version of the template."
       directory   = "./stable-template"
     },
     {
-      name        = "staging-${var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA}"
+      name        = "staging-${var.COMMIT_SHA}"
       description = "The staging version of the template."
       directory   = "./staging-template"
     }

--- a/examples/resources/coderd_template/resource.tf
+++ b/examples/resources/coderd_template/resource.tf
@@ -1,8 +1,8 @@
 // Provider populated from environment variables
 provider "coderd" {}
 
-// Get the commit SHA of the configuration's git repository
-variable "TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA" {
+// Can be populated using an environment variable, or an external datasource script
+variable "COMMIT_SHA" {
   type = string
 }
 
@@ -17,12 +17,12 @@ resource "coderd_template" "ubuntu-main" {
   description = "The main template for developing on Ubuntu."
   versions = [
     {
-      name        = "stable-${var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA}"
+      name        = "stable-${var.COMMIT_SHA}"
       description = "The stable version of the template."
       directory   = "./stable-template"
     },
     {
-      name        = "staging-${var.TFC_CONFIGURATION_VERSION_GIT_COMMIT_SHA}"
+      name        = "staging-${var.COMMIT_SHA}"
       description = "The staging version of the template."
       directory   = "./staging-template"
     }


### PR DESCRIPTION
The template example that used a Git commit hash in the name of each version referenced a Terraform variable that's only populated when using Terraform Cloud. There's not a great universal way to populate the variable within Terraform, so we'll instead mention two ways one could otherwise set it.