### PR TITLE
docs: add import examples

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   A group on the Coder deployment.
   Creating groups requires an Enterprise license.
-  When importing, the ID supplied can be either a group UUID retrieved via the API or <organization-name>/<group-name>.
 ---
 
 # coderd_group (Resource)
@@ -13,8 +12,6 @@ description: |-
 A group on the Coder deployment.
 
 Creating groups requires an Enterprise license.
-
-When importing, the ID supplied can be either a group UUID retrieved via the API or `<organization-name>/<group-name>`.
 
 ## Example Usage
 
@@ -62,3 +59,21 @@ resource "coderd_group" "group1" {
 ### Read-Only
 
 - `id` (String) Group ID.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# The ID supplied can be either a group UUID retrieved via the API
+# or a fully qualified name: `<organization-name>/<group-name>`.
+$ terraform import coderd_group.example coder/developers
+```
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_group.example
+  id = "coder/developers"
+}
+```

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -5,7 +5,6 @@ subcategory: ""
 description: |-
   A Coder template.
   Logs from building template versions can be optionally streamed from the provisioner by setting the TF_LOG environment variable to INFO or higher.
-  When importing, the ID supplied can be either a template UUID retrieved via the API or <organization-name>/<template-name>.
 ---
 
 # coderd_template (Resource)
@@ -13,8 +12,6 @@ description: |-
 A Coder template.
 
 Logs from building template versions can be optionally streamed from the provisioner by setting the `TF_LOG` environment variable to `INFO` or higher.
-
-When importing, the ID supplied can be either a template UUID retrieved via the API or `<organization-name>/<template-name>`.
 
 ## Example Usage
 
@@ -164,3 +161,25 @@ Optional:
 
 - `days_of_week` (Set of String) List of days of the week on which restarts are required. Restarts happen within the user's quiet hours (in their configured timezone). If no days are specified, restarts are not required.
 - `weeks` (Number) Weeks is the number of weeks between required restarts. Weeks are synced across all workspaces (and Coder deployments) using modulo math on a hardcoded epoch week of January 2nd, 2023 (the first Monday of 2023). Values of 0 or 1 indicate weekly restarts. Values of 2 indicate fortnightly restarts, etc.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# The ID supplied can be either a template UUID retrieved via the API
+# or a fully qualified name: `<organization-name>/<template-name>`.
+$ terraform import coderd_template.example coder/dogfood
+```
+Once imported, you'll need to manually declare in your config:
+- The `versions` list, in order to specify the source directories for new versions of the template.
+- (Enterprise) The `acl` attribute, in order to specify the users and groups that have access to the template.
+
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_template.example
+  id = "coder/dogfood"
+}
+```

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -4,14 +4,11 @@ page_title: "coderd_user Resource - terraform-provider-coderd"
 subcategory: ""
 description: |-
   A user on the Coder deployment.
-  When importing, the ID supplied can be either a user UUID or a username.
 ---
 
 # coderd_user (Resource)
 
 A user on the Coder deployment.
-
-When importing, the ID supplied can be either a user UUID or a username.
 
 ## Example Usage
 
@@ -65,3 +62,21 @@ resource "coderd_user" "admin" {
 ### Read-Only
 
 - `id` (String) User ID
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# The ID supplied can be either a user UUID retrieved via the API
+# or a username.
+$ terraform import coderd_user.example developer
+```
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_user.example
+  id = "developer"
+}
+```

--- a/examples/resources/coderd_group/import.sh
+++ b/examples/resources/coderd_group/import.sh
@@ -1,0 +1,11 @@
+# The ID supplied can be either a group UUID retrieved via the API
+# or a fully qualified name: `<organization-name>/<group-name>`.
+$ terraform import coderd_group.example coder/developers
+```
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_group.example
+  id = "coder/developers"
+}

--- a/examples/resources/coderd_template/import.sh
+++ b/examples/resources/coderd_template/import.sh
@@ -1,0 +1,15 @@
+# The ID supplied can be either a template UUID retrieved via the API
+# or a fully qualified name: `<organization-name>/<template-name>`.
+$ terraform import coderd_template.example coder/dogfood
+```
+Once imported, you'll need to manually declare in your config:
+- The `versions` list, in order to specify the source directories for new versions of the template.
+- (Enterprise) The `acl` attribute, in order to specify the users and groups that have access to the template.
+
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_template.example
+  id = "coder/dogfood"
+}

--- a/examples/resources/coderd_user/import.sh
+++ b/examples/resources/coderd_user/import.sh
@@ -1,0 +1,11 @@
+# The ID supplied can be either a user UUID retrieved via the API
+# or a username.
+$ terraform import coderd_user.example developer
+```
+Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
+
+```terraform
+import {
+  to = coderd_user.example
+  id = "developer"
+}

--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -62,8 +62,7 @@ func (r *GroupResource) Metadata(ctx context.Context, req resource.MetadataReque
 func (r *GroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "A group on the Coder deployment.\n\n" +
-			"Creating groups requires an Enterprise license.\n\n" +
-			"When importing, the ID supplied can be either a group UUID retrieved via the API or `<organization-name>/<group-name>`.",
+			"Creating groups requires an Enterprise license.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -243,9 +243,7 @@ func (r *TemplateResource) Metadata(ctx context.Context, req resource.MetadataRe
 func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "A Coder template.\n\nLogs from building template versions can be optionally streamed from the provisioner " +
-			"by setting the `TF_LOG` environment variable to `INFO` or higher.\n\n" +
-			"When importing, the ID supplied can be either a template UUID retrieved via the API or `<organization-name>/<template-name>`.",
-
+			"by setting the `TF_LOG` environment variable to `INFO` or higher.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the template.",

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -56,8 +56,7 @@ func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataReques
 
 func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "A user on the Coder deployment.\n\n" +
-			"When importing, the ID supplied can be either a user UUID or a username.",
+		MarkdownDescription: "A user on the Coder deployment.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{


### PR DESCRIPTION
Closes #117.

Replaces the sentence on imports at the top of each resource with an entire section at the bottom, like many other providers.

Appending extra content to the auto-gen'd docs is a pain (it gets overridden by go gen) so we just do some sneaky codeblock escaping within the shell files and it works nicely.