### PR TITLE
DNM: chore!: use map over list for template tf_vars & provisioner_tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,10 +58,9 @@ resource "coderd_template" "example" {
   versions = [{
     directory = "./example-template"
     active    = true
-    tf_vars = [{
-      name  = "image_id"
-      value = "ami-12345678"
-    }]
+    tf_vars = {
+      "image_id" = "ami-12345678"
+    }
     # Version names can be randomly generated if null/omitted
   }]
   acl = {

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -100,31 +100,13 @@ Optional:
 - `active` (Boolean) Whether this version is the active version of the template. Only one version can be active at a time.
 - `message` (String) A message describing the changes in this version of the template. Messages longer than 72 characters will be truncated.
 - `name` (String) The name of the template version. Automatically generated if not provided. If provided, the name *must* change each time the directory contents, or the `tf_vars` attribute are updated.
-- `provisioner_tags` (Attributes Set) Provisioner tags for the template version. (see [below for nested schema](#nestedatt--versions--provisioner_tags))
-- `tf_vars` (Attributes Set) Terraform variables for the template version. (see [below for nested schema](#nestedatt--versions--tf_vars))
+- `provisioner_tags` (Map of String) Provisioner tags for the template version.
+- `tf_vars` (Map of String) Terraform variables for the template version.
 
 Read-Only:
 
 - `directory_hash` (String)
 - `id` (String)
-
-<a id="nestedatt--versions--provisioner_tags"></a>
-### Nested Schema for `versions.provisioner_tags`
-
-Required:
-
-- `name` (String)
-- `value` (String)
-
-
-<a id="nestedatt--versions--tf_vars"></a>
-### Nested Schema for `versions.tf_vars`
-
-Required:
-
-- `name` (String)
-- `value` (String)
-
 
 
 <a id="nestedatt--acl"></a>

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -38,10 +38,9 @@ resource "coderd_template" "example" {
   versions = [{
     directory = "./example-template"
     active    = true
-    tf_vars = [{
-      name  = "image_id"
-      value = "ami-12345678"
-    }]
+    tf_vars = {
+      "image_id" = "ami-12345678"
+    }
     # Version names can be randomly generated if null/omitted
   }]
   acl = {

--- a/integration/template-test/main.tf
+++ b/integration/template-test/main.tf
@@ -43,22 +43,16 @@ resource "coderd_template" "sample" {
     {
       directory = "./example-template-2"
       active    = true
-      tf_vars = [
-        {
-          name  = "name"
-          value = "world"
-        },
-      ]
+      tf_vars = {
+        name = "world"
+      }
     },
     {
       directory = "./example-template-2"
       active    = false
-      tf_vars = [
-        {
-          name  = "name"
-          value = "ethan"
-        },
-      ]
+      tf_vars = {
+        name = "ethan"
+      }
     }
   ]
 }

--- a/internal/provider/template_data_source_test.go
+++ b/internal/provider/template_data_source_test.go
@@ -34,11 +34,8 @@ func TestAccTemplateDataSource(t *testing.T) {
 			Name:      types.StringValue("main"),
 			Message:   types.StringValue("Initial commit"),
 			Directory: types.StringValue("../../integration/template-test/example-template/"),
-			TerraformVariables: []Variable{
-				{
-					Name:  types.StringValue("name"),
-					Value: types.StringValue("world"),
-				},
+			TerraformVariables: map[string]string{
+				"name": "world",
 			},
 		},
 	})


### PR DESCRIPTION
Do not merge this PR until we're ready for a 1.0 release.

Closes #121.

For reference, seeing how poor the plan output is when modifying a *list* of `tf_vars` was what convinced me this was a worthwhile QOL change. That would drive me nuts if I was working with a bunch of them.