### PR TITLE
chore: replace `PtrTo` with `ptr.Ref`

### DIFF
--- a/internal/provider/group_data_source_test.go
+++ b/internal/provider/group_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -74,7 +75,7 @@ func TestAccGroupDataSource(t *testing.T) {
 		cfg := testAccGroupDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			ID:    PtrTo(group.ID.String()),
+			ID:    ptr.Ref(group.ID.String()),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -92,8 +93,8 @@ func TestAccGroupDataSource(t *testing.T) {
 		cfg := testAccGroupDataSourceConfig{
 			URL:            client.URL.String(),
 			Token:          client.SessionToken(),
-			OrganizationID: PtrTo(firstUser.OrganizationIDs[0].String()),
-			Name:           PtrTo("example-group"),
+			OrganizationID: ptr.Ref(firstUser.OrganizationIDs[0].String()),
+			Name:           ptr.Ref("example-group"),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -111,7 +112,7 @@ func TestAccGroupDataSource(t *testing.T) {
 		cfg := testAccGroupDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo("example-group"),
+			Name:  ptr.Ref("example-group"),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -129,7 +130,7 @@ func TestAccGroupDataSource(t *testing.T) {
 		cfg := testAccGroupDataSourceConfig{
 			URL:            client.URL.String(),
 			Token:          client.SessionToken(),
-			OrganizationID: PtrTo(firstUser.OrganizationIDs[0].String()),
+			OrganizationID: ptr.Ref(firstUser.OrganizationIDs[0].String()),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/group_resource_test.go
+++ b/internal/provider/group_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -44,17 +45,17 @@ func TestAccGroupResource(t *testing.T) {
 	cfg1 := testAccGroupResourceconfig{
 		URL:            client.URL.String(),
 		Token:          client.SessionToken(),
-		Name:           PtrTo("example-group"),
-		DisplayName:    PtrTo("Example Group"),
-		AvatarUrl:      PtrTo("https://google.com"),
-		QuotaAllowance: PtrTo(int32(100)),
-		Members:        PtrTo([]string{user1.ID.String()}),
+		Name:           ptr.Ref("example-group"),
+		DisplayName:    ptr.Ref("Example Group"),
+		AvatarUrl:      ptr.Ref("https://google.com"),
+		QuotaAllowance: ptr.Ref(int32(100)),
+		Members:        ptr.Ref([]string{user1.ID.String()}),
 	}
 
 	cfg2 := cfg1
-	cfg2.Name = PtrTo("example-group-new")
-	cfg2.DisplayName = PtrTo("Example Group New")
-	cfg2.Members = PtrTo([]string{user2.ID.String()})
+	cfg2.Name = ptr.Ref("example-group-new")
+	cfg2.DisplayName = ptr.Ref("Example Group New")
+	cfg2.Members = ptr.Ref([]string{user2.ID.String()})
 
 	cfg3 := cfg2
 	cfg3.Members = nil
@@ -143,11 +144,11 @@ func TestAccGroupResourceAGPL(t *testing.T) {
 	cfg1 := testAccGroupResourceconfig{
 		URL:            client.URL.String(),
 		Token:          client.SessionToken(),
-		Name:           PtrTo("example-group"),
-		DisplayName:    PtrTo("Example Group"),
-		AvatarUrl:      PtrTo("https://google.com"),
-		QuotaAllowance: PtrTo(int32(100)),
-		Members:        PtrTo([]string{firstUser.ID.String()}),
+		Name:           ptr.Ref("example-group"),
+		DisplayName:    ptr.Ref("Example Group"),
+		AvatarUrl:      ptr.Ref("https://google.com"),
+		QuotaAllowance: ptr.Ref(int32(100)),
+		Members:        ptr.Ref([]string{firstUser.ID.String()}),
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -37,7 +38,7 @@ func TestAccOrganizationDataSource(t *testing.T) {
 		cfg := testAccOrganizationDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			ID:    PtrTo(firstUser.OrganizationIDs[0].String()),
+			ID:    ptr.Ref(firstUser.OrganizationIDs[0].String()),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -55,7 +56,7 @@ func TestAccOrganizationDataSource(t *testing.T) {
 		cfg := testAccOrganizationDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo("coder"),
+			Name:  ptr.Ref("coder"),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -73,7 +74,7 @@ func TestAccOrganizationDataSource(t *testing.T) {
 		cfg := testAccOrganizationDataSourceConfig{
 			URL:       client.URL.String(),
 			Token:     client.SessionToken(),
-			IsDefault: PtrTo(true),
+			IsDefault: ptr.Ref(true),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -91,8 +92,8 @@ func TestAccOrganizationDataSource(t *testing.T) {
 		cfg := testAccOrganizationDataSourceConfig{
 			URL:       client.URL.String(),
 			Token:     client.SessionToken(),
-			IsDefault: PtrTo(true),
-			Name:      PtrTo("coder"),
+			IsDefault: ptr.Ref(true),
+			Name:      ptr.Ref("coder"),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/template_data_source_test.go
+++ b/internal/provider/template_data_source_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 )
@@ -49,8 +50,8 @@ func TestAccTemplateDataSource(t *testing.T) {
 		Description:        "An example template",
 		Icon:               "/path/to/icon.png",
 		VersionID:          version.ID,
-		DefaultTTLMillis:   PtrTo((10 * time.Hour).Milliseconds()),
-		ActivityBumpMillis: PtrTo((4 * time.Hour).Milliseconds()),
+		DefaultTTLMillis:   ptr.Ref((10 * time.Hour).Milliseconds()),
+		ActivityBumpMillis: ptr.Ref((4 * time.Hour).Milliseconds()),
 		AutostopRequirement: &codersdk.TemplateAutostopRequirement{
 			DaysOfWeek: []string{"sunday"},
 			Weeks:      1,
@@ -58,12 +59,12 @@ func TestAccTemplateDataSource(t *testing.T) {
 		AutostartRequirement: &codersdk.TemplateAutostartRequirement{
 			DaysOfWeek: []string{"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"},
 		},
-		AllowUserCancelWorkspaceJobs:   PtrTo(true),
-		AllowUserAutostart:             PtrTo(true),
-		AllowUserAutostop:              PtrTo(true),
-		FailureTTLMillis:               PtrTo((1 * time.Hour).Milliseconds()),
-		TimeTilDormantMillis:           PtrTo((7 * 24 * time.Hour).Milliseconds()),
-		TimeTilDormantAutoDeleteMillis: PtrTo((30 * 24 * time.Hour).Milliseconds()),
+		AllowUserCancelWorkspaceJobs:   ptr.Ref(true),
+		AllowUserAutostart:             ptr.Ref(true),
+		AllowUserAutostop:              ptr.Ref(true),
+		FailureTTLMillis:               ptr.Ref((1 * time.Hour).Milliseconds()),
+		TimeTilDormantMillis:           ptr.Ref((7 * 24 * time.Hour).Milliseconds()),
+		TimeTilDormantAutoDeleteMillis: ptr.Ref((30 * 24 * time.Hour).Milliseconds()),
 		DisableEveryoneGroupAccess:     true,
 		RequireActiveVersion:           true,
 	})
@@ -93,9 +94,9 @@ func TestAccTemplateDataSource(t *testing.T) {
 		UpdateWorkspaceLastUsedAt:      false,
 		UpdateWorkspaceDormantAt:       false,
 		RequireActiveVersion:           tpl.RequireActiveVersion,
-		DeprecationMessage:             PtrTo("This template is deprecated"),
+		DeprecationMessage:             ptr.Ref("This template is deprecated"),
 		DisableEveryoneGroupAccess:     true,
-		MaxPortShareLevel:              PtrTo(codersdk.WorkspaceAgentPortShareLevelOwner),
+		MaxPortShareLevel:              ptr.Ref(codersdk.WorkspaceAgentPortShareLevelOwner),
 	})
 	require.NoError(t, err)
 
@@ -153,8 +154,8 @@ func TestAccTemplateDataSource(t *testing.T) {
 		cfg := testAccTemplateDataSourceConfig{
 			URL:            client.URL.String(),
 			Token:          client.SessionToken(),
-			OrganizationID: PtrTo(orgID.String()),
-			Name:           PtrTo(tpl.Name),
+			OrganizationID: ptr.Ref(orgID.String()),
+			Name:           ptr.Ref(tpl.Name),
 		}
 		resource.Test(t, resource.TestCase{
 			IsUnitTest:               true,
@@ -173,7 +174,7 @@ func TestAccTemplateDataSource(t *testing.T) {
 		cfg := testAccTemplateDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			ID:    PtrTo(tpl.ID.String()),
+			ID:    ptr.Ref(tpl.ID.String()),
 		}
 		resource.Test(t, resource.TestCase{
 			IsUnitTest:               true,
@@ -210,7 +211,7 @@ func TestAccTemplateDataSource(t *testing.T) {
 		cfg := testAccTemplateDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo(tpl.Name),
+			Name:  ptr.Ref(tpl.Name),
 		}
 		resource.Test(t, resource.TestCase{
 			IsUnitTest:               true,

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"cdr.dev/slog"
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/coder/v2/provisionersdk"
 	"github.com/google/uuid"
@@ -1253,7 +1254,7 @@ func (r *TemplateResourceModel) toUpdateRequest(ctx context.Context, diag *diag.
 		TimeTilDormantAutoDeleteMillis: r.TimeTilDormantAutoDeleteMillis.ValueInt64(),
 		RequireActiveVersion:           r.RequireActiveVersion.ValueBool(),
 		DeprecationMessage:             r.DeprecationMessage.ValueStringPointer(),
-		MaxPortShareLevel:              PtrTo(codersdk.WorkspaceAgentPortShareLevel(r.MaxPortShareLevel.ValueString())),
+		MaxPortShareLevel:              ptr.Ref(codersdk.WorkspaceAgentPortShareLevel(r.MaxPortShareLevel.ValueString())),
 		// If we're managing ACL, we want to delete the everyone group
 		DisableEveryoneGroupAccess: !r.ACL.IsNull(),
 	}

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -17,6 +17,7 @@ import (
 	cp "github.com/otiai10/copy"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 )
@@ -42,12 +43,12 @@ func TestAccTemplateResource(t *testing.T) {
 		cfg1 := testAccTemplateResourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo("example-template"),
+			Name:  ptr.Ref("example-template"),
 			Versions: []testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
-					Active:    PtrTo(true),
+					Active:    ptr.Ref(true),
 				},
 			},
 			ACL: testAccTemplateACLConfig{
@@ -57,28 +58,28 @@ func TestAccTemplateResource(t *testing.T) {
 
 		cfg2 := cfg1
 		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Name = PtrTo("example-template-new")
+		cfg2.Name = ptr.Ref("example-template-new")
 		cfg2.Versions[0].Directory = &exTemplateTwo
-		cfg2.Versions[0].Name = PtrTo("new")
+		cfg2.Versions[0].Name = ptr.Ref("new")
 
 		cfg3 := cfg2
 		cfg3.Versions = slices.Clone(cfg3.Versions)
 		cfg3.Versions = append(cfg3.Versions, testAccTemplateVersionConfig{
-			Name:      PtrTo("legacy-template"),
+			Name:      ptr.Ref("legacy-template"),
 			Directory: &exTemplateOne,
-			Active:    PtrTo(false),
+			Active:    ptr.Ref(false),
 			TerraformVariables: []testAccTemplateKeyValueConfig{
 				{
-					Key:   PtrTo("name"),
-					Value: PtrTo("world"),
+					Key:   ptr.Ref("name"),
+					Value: ptr.Ref("world"),
 				},
 			},
 		})
 
 		cfg4 := cfg3
 		cfg4.Versions = slices.Clone(cfg4.Versions)
-		cfg4.Versions[0].Active = PtrTo(false)
-		cfg4.Versions[1].Active = PtrTo(true)
+		cfg4.Versions[0].Active = ptr.Ref(false)
+		cfg4.Versions[1].Active = ptr.Ref(true)
 
 		cfg5 := cfg4
 		cfg5.Versions = slices.Clone(cfg5.Versions)
@@ -240,26 +241,26 @@ func TestAccTemplateResource(t *testing.T) {
 		cfg1 := testAccTemplateResourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo("example-template2"),
+			Name:  ptr.Ref("example-template2"),
 			Versions: []testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
-					Directory: PtrTo("../../integration/template-test/example-template-2/"),
+					Directory: ptr.Ref("../../integration/template-test/example-template-2/"),
 					TerraformVariables: []testAccTemplateKeyValueConfig{
 						{
-							Key:   PtrTo("name"),
-							Value: PtrTo("world"),
+							Key:   ptr.Ref("name"),
+							Value: ptr.Ref("world"),
 						},
 					},
-					Active: PtrTo(true),
+					Active: ptr.Ref(true),
 				},
 				{
 					// Auto-generated version name
-					Directory: PtrTo("../../integration/template-test/example-template-2/"),
+					Directory: ptr.Ref("../../integration/template-test/example-template-2/"),
 					TerraformVariables: []testAccTemplateKeyValueConfig{
 						{
-							Key:   PtrTo("name"),
-							Value: PtrTo("world"),
+							Key:   ptr.Ref("name"),
+							Value: ptr.Ref("world"),
 						},
 					},
 				},
@@ -271,28 +272,28 @@ func TestAccTemplateResource(t *testing.T) {
 
 		cfg2 := cfg1
 		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[1].Name = PtrTo("new-name")
+		cfg2.Versions[1].Name = ptr.Ref("new-name")
 
 		cfg3 := cfg2
 		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions[0].Name = PtrTo("new-name-one")
-		cfg3.Versions[1].Name = PtrTo("new-name-two")
+		cfg3.Versions[0].Name = ptr.Ref("new-name-one")
+		cfg3.Versions[1].Name = ptr.Ref("new-name-two")
 		cfg3.Versions[0], cfg3.Versions[1] = cfg3.Versions[1], cfg3.Versions[0]
 
 		cfg4 := cfg1
 		cfg4.Versions = slices.Clone(cfg4.Versions)
-		cfg4.Versions[0].Directory = PtrTo("../../integration/template-test/example-template/")
+		cfg4.Versions[0].Directory = ptr.Ref("../../integration/template-test/example-template/")
 
 		cfg5 := cfg4
 		cfg5.Versions = slices.Clone(cfg5.Versions)
-		cfg5.Versions[1].Directory = PtrTo("../../integration/template-test/example-template/")
+		cfg5.Versions[1].Directory = ptr.Ref("../../integration/template-test/example-template/")
 
 		cfg6 := cfg5
 		cfg6.Versions = slices.Clone(cfg6.Versions)
 		cfg6.Versions[0].TerraformVariables = []testAccTemplateKeyValueConfig{
 			{
-				Key:   PtrTo("name"),
-				Value: PtrTo("world2"),
+				Key:   ptr.Ref("name"),
+				Value: ptr.Ref("world2"),
 			},
 		}
 
@@ -368,18 +369,18 @@ func TestAccTemplateResource(t *testing.T) {
 		cfg1 := testAccTemplateResourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			Name:  PtrTo("example-template3"),
+			Name:  ptr.Ref("example-template3"),
 			Versions: []testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
-					Directory: PtrTo("../../integration/template-test/example-template-2/"),
+					Directory: ptr.Ref("../../integration/template-test/example-template-2/"),
 					TerraformVariables: []testAccTemplateKeyValueConfig{
 						{
-							Key:   PtrTo("name"),
-							Value: PtrTo("world"),
+							Key:   ptr.Ref("name"),
+							Value: ptr.Ref("world"),
 						},
 					},
-					Active: PtrTo(true),
+					Active: ptr.Ref(true),
 				},
 			},
 			ACL: testAccTemplateACLConfig{
@@ -391,8 +392,8 @@ func TestAccTemplateResource(t *testing.T) {
 		cfg2.Versions = slices.Clone(cfg2.Versions)
 		cfg2.Versions[0].TerraformVariables = []testAccTemplateKeyValueConfig{
 			{
-				Key:   PtrTo("name"),
-				Value: PtrTo("world2"),
+				Key:   ptr.Ref("name"),
+				Value: ptr.Ref("world2"),
 			},
 		}
 
@@ -436,29 +437,29 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 	cfg1 := testAccTemplateResourceConfig{
 		URL:   client.URL.String(),
 		Token: client.SessionToken(),
-		Name:  PtrTo("example-template"),
+		Name:  ptr.Ref("example-template"),
 		Versions: []testAccTemplateVersionConfig{
 			{
 				// Auto-generated version name
-				Directory: PtrTo("../../integration/template-test/example-template"),
-				Active:    PtrTo(true),
+				Directory: ptr.Ref("../../integration/template-test/example-template"),
+				Active:    ptr.Ref(true),
 			},
 		},
 		ACL: testAccTemplateACLConfig{
 			GroupACL: []testAccTemplateKeyValueConfig{
 				{
-					Key:   PtrTo(firstUser.OrganizationIDs[0].String()),
-					Value: PtrTo("use"),
+					Key:   ptr.Ref(firstUser.OrganizationIDs[0].String()),
+					Value: ptr.Ref("use"),
 				},
 				{
-					Key:   PtrTo(group.ID.String()),
-					Value: PtrTo("admin"),
+					Key:   ptr.Ref(group.ID.String()),
+					Value: ptr.Ref("admin"),
 				},
 			},
 			UserACL: []testAccTemplateKeyValueConfig{
 				{
-					Key:   PtrTo(firstUser.ID.String()),
-					Value: PtrTo("admin"),
+					Key:   ptr.Ref(firstUser.ID.String()),
+					Value: ptr.Ref("admin"),
 				},
 			},
 		},
@@ -466,17 +467,17 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 
 	cfg2 := cfg1
 	cfg2.ACL.GroupACL = slices.Clone(cfg2.ACL.GroupACL[1:])
-	cfg2.MaxPortShareLevel = PtrTo("owner")
+	cfg2.MaxPortShareLevel = ptr.Ref("owner")
 
 	cfg3 := cfg2
 	cfg3.ACL.null = true
-	cfg3.MaxPortShareLevel = PtrTo("public")
+	cfg3.MaxPortShareLevel = ptr.Ref("public")
 
 	cfg4 := cfg3
-	cfg4.AllowUserAutostart = PtrTo(false)
+	cfg4.AllowUserAutostart = ptr.Ref(false)
 	cfg4.AutostopRequirement = testAccAutostopRequirementConfig{
-		DaysOfWeek: PtrTo([]string{"monday", "tuesday"}),
-		Weeks:      PtrTo(int64(2)),
+		DaysOfWeek: ptr.Ref([]string{"monday", "tuesday"}),
+		Weeks:      ptr.Ref(int64(2)),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -571,47 +572,47 @@ func TestAccTemplateResourceAGPL(t *testing.T) {
 	cfg1 := testAccTemplateResourceConfig{
 		URL:   client.URL.String(),
 		Token: client.SessionToken(),
-		Name:  PtrTo("example-template"),
+		Name:  ptr.Ref("example-template"),
 		Versions: []testAccTemplateVersionConfig{
 			{
 				// Auto-generated version name
-				Directory: PtrTo("../../integration/template-test/example-template/"),
-				Active:    PtrTo(true),
+				Directory: ptr.Ref("../../integration/template-test/example-template/"),
+				Active:    ptr.Ref(true),
 			},
 		},
-		AllowUserAutostart: PtrTo(false),
+		AllowUserAutostart: ptr.Ref(false),
 	}
 
 	cfg2 := cfg1
 	cfg2.AllowUserAutostart = nil
-	cfg2.AutostopRequirement.DaysOfWeek = PtrTo([]string{"monday", "tuesday"})
+	cfg2.AutostopRequirement.DaysOfWeek = ptr.Ref([]string{"monday", "tuesday"})
 
 	cfg3 := cfg2
 	cfg3.AutostopRequirement.null = true
-	cfg3.AutostartRequirement = PtrTo([]string{})
+	cfg3.AutostartRequirement = ptr.Ref([]string{})
 
 	cfg4 := cfg3
-	cfg4.FailureTTL = PtrTo(int64(1))
+	cfg4.FailureTTL = ptr.Ref(int64(1))
 
 	cfg5 := cfg4
 	cfg5.FailureTTL = nil
 	cfg5.AutostartRequirement = nil
-	cfg5.RequireActiveVersion = PtrTo(true)
+	cfg5.RequireActiveVersion = ptr.Ref(true)
 
 	cfg6 := cfg5
 	cfg6.RequireActiveVersion = nil
 	cfg6.ACL = testAccTemplateACLConfig{
 		GroupACL: []testAccTemplateKeyValueConfig{
 			{
-				Key:   PtrTo(firstUser.OrganizationIDs[0].String()),
-				Value: PtrTo("use"),
+				Key:   ptr.Ref(firstUser.OrganizationIDs[0].String()),
+				Value: ptr.Ref("use"),
 			},
 		},
 	}
 
 	cfg7 := cfg6
 	cfg7.ACL.null = true
-	cfg7.MaxPortShareLevel = PtrTo("owner")
+	cfg7.MaxPortShareLevel = ptr.Ref("owner")
 
 	for _, cfg := range []testAccTemplateResourceConfig{cfg1, cfg2, cfg3, cfg4} {
 		resource.Test(t, resource.TestCase{

--- a/internal/provider/user_data_source_test.go
+++ b/internal/provider/user_data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -53,7 +54,7 @@ func TestAccUserDataSource(t *testing.T) {
 		cfg := testAccUserDataSourceConfig{
 			URL:      client.URL.String(),
 			Token:    client.SessionToken(),
-			Username: PtrTo(user.Username),
+			Username: ptr.Ref(user.Username),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -71,7 +72,7 @@ func TestAccUserDataSource(t *testing.T) {
 		cfg := testAccUserDataSourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
-			ID:    PtrTo(user.ID.String()),
+			ID:    ptr.Ref(user.ID.String()),
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
@@ -22,22 +23,22 @@ func TestAccUserResource(t *testing.T) {
 	cfg1 := testAccUserResourceConfig{
 		URL:       client.URL.String(),
 		Token:     client.SessionToken(),
-		Username:  PtrTo("example"),
-		Name:      PtrTo("Example User"),
-		Email:     PtrTo("example@coder.com"),
-		Roles:     PtrTo([]string{"owner", "auditor"}),
-		LoginType: PtrTo("password"),
-		Password:  PtrTo("SomeSecurePassword!"),
+		Username:  ptr.Ref("example"),
+		Name:      ptr.Ref("Example User"),
+		Email:     ptr.Ref("example@coder.com"),
+		Roles:     ptr.Ref([]string{"owner", "auditor"}),
+		LoginType: ptr.Ref("password"),
+		Password:  ptr.Ref("SomeSecurePassword!"),
 	}
 
 	cfg2 := cfg1
-	cfg2.Username = PtrTo("exampleNew")
+	cfg2.Username = ptr.Ref("exampleNew")
 
 	cfg3 := cfg2
-	cfg3.Name = PtrTo("Example New")
+	cfg3.Name = ptr.Ref("Example New")
 
 	cfg4 := cfg3
-	cfg4.LoginType = PtrTo("github")
+	cfg4.LoginType = ptr.Ref("github")
 	cfg4.Password = nil
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -20,10 +20,6 @@ var (
 	displayNameRegex         = regexp.MustCompile(`^[^\s](.*[^\s])?$`)
 )
 
-func PtrTo[T any](v T) *T {
-	return &v
-}
-
 func PrintOrNull(v any) string {
 	if v == nil {
 		return "null"

--- a/internal/provider/workspace_proxy_resource_test.go
+++ b/internal/provider/workspace_proxy_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/coder/coder/v2/coderd/util/ptr"
 	"github.com/coder/terraform-provider-coderd/integration"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/require"
@@ -23,14 +24,14 @@ func TestAccWorkspaceProxyResource(t *testing.T) {
 	cfg1 := testAccWorkspaceProxyResourceConfig{
 		URL:         client.URL.String(),
 		Token:       client.SessionToken(),
-		Name:        PtrTo("example"),
-		DisplayName: PtrTo("Example WS Proxy"),
-		Icon:        PtrTo("/emojis/1f407.png"),
+		Name:        ptr.Ref("example"),
+		DisplayName: ptr.Ref("Example WS Proxy"),
+		Icon:        ptr.Ref("/emojis/1f407.png"),
 	}
 
 	cfg2 := cfg1
-	cfg2.Name = PtrTo("example-new")
-	cfg2.DisplayName = PtrTo("Example WS Proxy New")
+	cfg2.Name = ptr.Ref("example-new")
+	cfg2.DisplayName = ptr.Ref("Example WS Proxy New")
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               true,
@@ -64,9 +65,9 @@ func TestAccWorkspaceProxyResourceAGPL(t *testing.T) {
 	cfg1 := testAccWorkspaceProxyResourceConfig{
 		URL:         client.URL.String(),
 		Token:       client.SessionToken(),
-		Name:        PtrTo("example"),
-		DisplayName: PtrTo("Example WS Proxy"),
-		Icon:        PtrTo("/emojis/1f407.png"),
+		Name:        ptr.Ref("example"),
+		DisplayName: ptr.Ref("Example WS Proxy"),
+		Icon:        ptr.Ref("/emojis/1f407.png"),
 	}
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
we already import coder/coder into this repo, and it's nice to have one name for things across code bases