### PR TITLE
fix: mark invalid UUIDs as known

### DIFF
--- a/internal/provider/user_data_source_test.go
+++ b/internal/provider/user_data_source_test.go
@@ -57,6 +57,7 @@ func TestAccUserDataSource(t *testing.T) {
 			Username: ptr.Ref(user.Username),
 		}
 		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
@@ -75,6 +76,7 @@ func TestAccUserDataSource(t *testing.T) {
 			ID:    ptr.Ref(user.ID.String()),
 		}
 		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			// User by ID
@@ -92,6 +94,7 @@ func TestAccUserDataSource(t *testing.T) {
 			Token: client.SessionToken(),
 		}
 		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			// Neither ID nor Username
@@ -104,6 +107,24 @@ func TestAccUserDataSource(t *testing.T) {
 		})
 	})
 
+	t.Run("InvalidUUIDError", func(t *testing.T) {
+		cfg := testAccUserDataSourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			ID:    ptr.Ref("invalid-uuid"),
+		}
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      cfg.String(t),
+					ExpectError: regexp.MustCompile(`The provided value cannot be parsed as a UUID`),
+				},
+			},
+		})
+	})
 }
 
 type testAccUserDataSourceConfig struct {

--- a/internal/provider/uuid.go
+++ b/internal/provider/uuid.go
@@ -48,16 +48,16 @@ func (t uuidType) ValueFromString(ctx context.Context, in basetypes.StringValue)
 		return NewUUIDUnknown(), diags
 	}
 
-	value, err := uuid.Parse(in.ValueString())
-	if err != nil {
-		// The framework doesn't want us to return validation errors here
-		// for some reason. They get caught by `ValidateAttribute` instead,
-		// and this function isn't called directly by our provider - UUIDValue
-		// takes a valid UUID instead of a string.
-		return NewUUIDUnknown(), diags
-	}
-
-	return UUIDValue(value), diags
+	// This function deliberately does not handle invalid UUIDs.
+	// Instead, `ValidateAttribute` will be called
+	// on the stored string during `validate` `plan` and `apply`,
+	// which will also create an error diagnostic.
+	// For that reason, storing the zero UUID is fine.
+	v, _ := uuid.Parse(in.ValueString())
+	return UUID{
+		StringValue: in,
+		value:       v,
+	}, diags
 }
 
 // ValueFromTerraform implements basetypes.StringTypable.

--- a/internal/provider/uuid_internal_test.go
+++ b/internal/provider/uuid_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/require"
 )
@@ -37,9 +38,12 @@ func TestUUIDTypeValueFromTerraform(t *testing.T) {
 			expected: UUIDValue(ValidUUID),
 		},
 		{
-			name:     "invalid UUID",
-			input:    tftypes.NewValue(tftypes.String, "invalid"),
-			expected: NewUUIDUnknown(),
+			name:  "invalid UUID",
+			input: tftypes.NewValue(tftypes.String, "invalid"),
+			expected: UUID{
+				StringValue: basetypes.NewStringValue("invalid"),
+				value:       uuid.Nil,
+			},
 		},
 	}
 


### PR DESCRIPTION
When I first implemented the UUID Terraform type, I followed the example from `terraform-provider-aws` for durations: [Source](https://sourcegraph.com/github.com/hashicorp/terraform-provider-aws/-/blob/internal/framework/types/duration.go). This example doesn't quite make sense, or at the least isn't applicable to our use-case, and since it was used as a base for our custom data type, resulted in UUIDs not being validated when written as strings in a configuration.

i.e. This function is called by the plugin SDK, when reading the config.
```
func (t durationType) ValueFromString(_ context.Context, in types.String) (basetypes.StringValuable, diag.Diagnostics) {
       [...]
	valueString := in.ValueString()
	if _, err := time.ParseDuration(valueString); err != nil {
		return DurationUnknown(), diags // Must not return validation errors
	}
       [...]
}
```
Meanwhile, this function is called during `validate`/`plan`/apply:
```
func (v Duration) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
	if v.IsNull() || v.IsUnknown() {
		return
	}
}
```
This means if the duration couldn't be parsed, the value becomes unknown, and then is never validated, and so the provider just sees an Unknown value instead of an error diagnostic.

It's worth noting that you *cannot* remove the `IsUnknown` check from a validate function, as Terraform purposefully calls validate functions with unknown values when the attribute is set using a variable. The idea being to validate a config before and after any variables are populated. Therefore the only solution here is to return a *known*, *valid* value, if the UUID couldn't be parsed, as to let the validator handle it.

A similar data type is implemented in such a way that meets our use case for `arn` in `terraform-provider-aws`, which has been used as a guide for this fix: [Source](https://github.com/hashicorp/terraform-provider-aws/blob/0c9edd45ad5b079fe7186bf8ac957371a964811c/internal/framework/types/arn.go). In this provider, if an ARN can't be parsed, a valid & known value is returned from `ValueFromString`.

More importantly, I made the mistake of not testing the UUID type failing to parse in the context of a resource / data source. I only wrote internal unit tests for the type. This PR adds a test that ensures an error diagnostic is returned if an invalid UUID is provided to a resource/data-source UUID attribute, which tells us the problem is fixed.
