### PR TITLE
docs: add URL scheme to example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ terraform {
 }
 
 provider "coderd" {
-  url   = "coder.example.com"
+  url   = "https://coder.example.com"
   token = "****"
 }
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 provider "coderd" {
-  url   = "coder.example.com"
+  url   = "https://coder.example.com"
   token = "****"
 }
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -95,7 +95,7 @@ func StartCoder(ctx context.Context, t *testing.T, name string, useLicense bool)
 			t.Logf("not ready yet: %s", err.Error())
 		}
 		return err == nil
-	}, 15*time.Second, time.Second, "coder failed to become ready in time")
+	}, 20*time.Second, time.Second, "coder failed to become ready in time")
 	_, err = client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
 		Email:    testEmail,
 		Username: testUsername,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -101,7 +102,16 @@ func (p *CoderdProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		data.Token = types.StringValue(tokenEnv)
 	}
 
-	url, err := url.Parse(data.URL.ValueString())
+	rawURL := data.URL.ValueString()
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		scheme := "https"
+		if strings.HasPrefix(rawURL, "localhost") {
+			scheme = "http"
+		}
+		rawURL = fmt.Sprintf("%s://%s", scheme, rawURL)
+	}
+
+	url, err := url.Parse(rawURL)
 	if err != nil {
 		resp.Diagnostics.AddError("url", "url is not a valid URL: "+err.Error())
 		return


### PR DESCRIPTION
Closes #159.

This updates the documentation to include the access URL scheme in the example, matching the coder.com docs.

It also implicitly adds the scheme to the provided access URL if not present, only prepending `http://` if the access URL is localhost. This is the same behaviour as `coder login`.