### PR TITLE
fix: use server computed org display name

### DIFF
--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -119,7 +119,6 @@ This resource is only compatible with Coder version [2.16.0](https://github.com/
 				MarkdownDescription: "Display name of the organization. Defaults to name.",
 				Computed:            true,
 				Optional:            true,
-				Default:             stringdefault.StaticString(""),
 				Validators: []validator.String{
 					codersdkvalidator.DisplayName(),
 				},

--- a/internal/provider/organization_resource_test.go
+++ b/internal/provider/organization_resource_test.go
@@ -99,6 +99,29 @@ func TestAccOrganizationResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("DefaultDisplayName", func(t *testing.T) {
+		cfg1 := testAccOrganizationResourceConfig{
+			URL:         client.URL.String(),
+			Token:       client.SessionToken(),
+			Name:        ptr.Ref("example-org"),
+			Description: ptr.Ref("This is an example organization"),
+			Icon:        ptr.Ref("/icon/coder.svg"),
+		}
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: cfg1.String(t),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue("coderd_organization.test", tfjsonpath.New("display_name"), knownvalue.StringExact("example-org")),
+					},
+				},
+			},
+		})
+	})
 }
 
 type testAccOrganizationResourceConfig struct {


### PR DESCRIPTION
I picked up on this reviewing #182, but it's a mistake I made when reviewing the resource originally 😓 

There's a minor inconsistency between display names on orgs and some other resources with display names on `coderd`. i.e. for organizations:
```
if req.DisplayName == "" {
	req.DisplayName = req.Name
}
```
For some other resources, e.g. users & groups, an empty string display name is retained, and the CLI/Web UI just shows the actual name if the display name is empty. For those, it's okay to have an empty string default in the provider.