### PR TITLE
fix: avoid sending template metadata update if `max_port_share_level` is default

### DIFF
--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -573,6 +573,8 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	// deployment running `v2.15.0` or later.
 	if data.MaxPortShareLevel.IsUnknown() {
 		data.MaxPortShareLevel = types.StringValue(string(templateResp.MaxPortShareLevel))
+	} else if data.MaxPortShareLevel.ValueString() == string(templateResp.MaxPortShareLevel) {
+		tflog.Info(ctx, "max port share level set to default, not updating")
 	} else {
 		mpslReq := data.toUpdateRequest(ctx, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {


### PR DESCRIPTION
Closes #188.

For context, the `MaxPortShareLevel` template metadata value was not present on the `coderd` create template request prior to 2.15. As such, during template creation we need to send an update request for backwards compatibility (though we could probably remove this soon), see #110.

Whilst we don't send this update request is the attribute is omitted on the resource, we were sending a spurious update request if the value was explicitly configured to the default value ('owner' for enterprise+, 'public' otherwise). This was causing the error in the linked issue. An example is seen in the newly added test. 

The fix is to just not send that update request if the configured value is:
- Unknown
- Equal to the value on the newly created template.

note: I'd recommend hiding the whitespace when reviewing the diff