### PR TITLE
fix: support unmanaged roles on user resource

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -56,7 +56,7 @@ resource "coderd_user" "admin" {
 - `login_type` (String) Type of login for the user. Valid types are `none`, `password`, `github`, and `oidc`.
 - `name` (String) Display name of the user. Defaults to username.
 - `password` (String, Sensitive) Password for the user. Required when `login_type` is `password`. Passwords are saved into the state as plain text and should only be used for testing purposes.
-- `roles` (Set of String) Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`.
+- `roles` (Set of String) Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`. If `null`, roles will not be managed by Terraform. This attribute must be null if the user is an OIDC user and role sync is configured
 - `suspended` (Boolean) Whether the user is suspended.
 
 ### Read-Only

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -96,7 +96,7 @@ func StartCoder(ctx context.Context, t *testing.T, name string, useLicense bool)
 			t.Logf("not ready yet: %s", err.Error())
 		}
 		return err == nil
-	}, 20*time.Second, time.Second, "coder failed to become ready in time")
+	}, 30*time.Second, time.Second, "coder failed to become ready in time")
 	_, err = client.CreateFirstUser(ctx, codersdk.CreateFirstUserRequest{
 		Email:    testEmail,
 		Username: testUsername,

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -88,7 +88,6 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			},
 			"roles": schema.SetAttribute{
 				MarkdownDescription: "Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`. If `null`, roles will not be managed by Terraform. This attribute must be null if the user is an OIDC user and role sync is configured",
-				Computed:            true,
 				Optional:            true,
 				ElementType:         types.StringType,
 				Validators: []validator.Set{

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -87,7 +87,7 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Required:            true,
 			},
 			"roles": schema.SetAttribute{
-				MarkdownDescription: "Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`. If `null`, roles will not be managed by Terraform. This attribute must be null if the user was created via OIDC and uses role sync.",
+				MarkdownDescription: "Roles assigned to the user. Valid roles are `owner`, `template-admin`, `user-admin`, and `auditor`. If `null`, roles will not be managed by Terraform. This attribute must be null if the user is an OIDC user and role sync is configured",
 				Computed:            true,
 				Optional:            true,
 				ElementType:         types.StringType,

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -42,6 +42,9 @@ func TestAccUserResource(t *testing.T) {
 	cfg4.LoginType = ptr.Ref("github")
 	cfg4.Password = nil
 
+	cfg5 := cfg4
+	cfg5.Roles = nil
+
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               true,
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -114,7 +117,41 @@ func TestAccUserResource(t *testing.T) {
 				// The Plan should be to create the entire resource
 				ExpectNonEmptyPlan: true,
 			},
+			// Unmanaged roles
+			{
+				Config: cfg5.String(t),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("coderd_user.test", "roles"),
+				),
+			},
 		},
+	})
+
+	t.Run("CreateUnmanagedRolesOk", func(t *testing.T) {
+		cfg := testAccUserResourceConfig{
+			URL:       client.URL.String(),
+			Token:     client.SessionToken(),
+			Username:  ptr.Ref("unmanaged"),
+			Name:      ptr.Ref("Unmanaged User"),
+			Email:     ptr.Ref("unmanaged@coder.com"),
+			Roles:     nil, // Start with unmanaged roles
+			LoginType: ptr.Ref("password"),
+			Password:  ptr.Ref("SomeSecurePassword!"),
+		}
+
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: cfg.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr("coderd_user.test", "roles"),
+					),
+				},
+			},
+		})
 	})
 }
 

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -71,7 +71,7 @@ func TestAccUserResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// We can't pull the password from the API.
-				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateVerifyIgnore: []string{"password", "roles"},
 			},
 			// ImportState by username
 			{
@@ -80,7 +80,7 @@ func TestAccUserResource(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateId:     "example",
 				// We can't pull the password from the API.
-				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateVerifyIgnore: []string{"password", "roles"},
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
A customer ran into an issue when creating an OIDC user while role sync was enabled on the deployment:
```
Error: 'User Role Field' is set in the OIDC configuration. All role changes must come from the oidc identity provider. 
```
This is because we always call `UpdateUserRoles` on `Create` and `Update`.

OIDC User roles cannot be managed via the API if role sync is used, as the API always returns an error on any role update request. 

With this PR, `roles` can now be set to `null` in the config, whereby the Terraform provider will not attempt to read or update the user's roles under any circumstances. This prevents config drift when roles are set via Role Sync.