### PR TITLE
fix: Add `organization` option for workspace port sharing

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -146,6 +146,17 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
+			name: "template-port-share-test",
+			preF: func(t testing.TB, c *codersdk.Client) {},
+			assertF: func(t testing.TB, c *codersdk.Client) {
+				templates, err := c.Templates(ctx, codersdk.TemplateFilter{})
+				require.NoError(t, err)
+				require.Len(t, templates, 1)
+				require.Equal(t, "port-share-test", templates[0].Name)
+				require.Equal(t, codersdk.WorkspaceAgentPortShareLevelOrganization, templates[0].MaxPortShareLevel)
+			},
+		},
+		{
 			name: "template-test",
 			preF: func(t testing.TB, c *codersdk.Client) {},
 			assertF: func(t testing.TB, c *codersdk.Client) {

--- a/integration/template-port-share-test/example-template/main.tf
+++ b/integration/template-port-share-test/example-template/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "a" {}

--- a/integration/template-port-share-test/main.tf
+++ b/integration/template-port-share-test/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    coderd = {
+      source  = "coder/coderd"
+      version = ">=0.0.0"
+    }
+  }
+}
+
+resource "coderd_template" "port_share" {
+  name                 = "port-share-test"
+  max_port_share_level = "organization"
+  versions = [
+    {
+      directory = "./example-template"
+      active    = true
+    }
+  ]
+}

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -40,9 +40,11 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &TemplateResource{}
-var _ resource.ResourceWithImportState = &TemplateResource{}
-var _ resource.ResourceWithConfigValidators = &TemplateResource{}
+var (
+	_ resource.Resource                     = &TemplateResource{}
+	_ resource.ResourceWithImportState      = &TemplateResource{}
+	_ resource.ResourceWithConfigValidators = &TemplateResource{}
+)
 
 func NewTemplateResource() resource.Resource {
 	return &TemplateResource{}
@@ -390,7 +392,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 				Computed:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOfCaseInsensitive(string(codersdk.WorkspaceAgentPortShareLevelAuthenticated), string(codersdk.WorkspaceAgentPortShareLevelOwner), string(codersdk.WorkspaceAgentPortShareLevelPublic)),
+					stringvalidator.OneOfCaseInsensitive(string(codersdk.WorkspaceAgentPortShareLevelAuthenticated), string(codersdk.WorkspaceAgentPortShareLevelOrganization), string(codersdk.WorkspaceAgentPortShareLevelOwner), string(codersdk.WorkspaceAgentPortShareLevelPublic)),
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -1251,11 +1253,11 @@ func markActive(ctx context.Context, client *codersdk.Client, templateID uuid.UU
 }
 
 func convertACLToRequest(curACL codersdk.TemplateACL, newACL ACL) codersdk.UpdateTemplateACL {
-	var userPerms = make(map[string]codersdk.TemplateRole)
+	userPerms := make(map[string]codersdk.TemplateRole)
 	for _, perm := range newACL.UserPermissions {
 		userPerms[perm.ID.ValueString()] = codersdk.TemplateRole(perm.Role.ValueString())
 	}
-	var groupPerms = make(map[string]codersdk.TemplateRole)
+	groupPerms := make(map[string]codersdk.TemplateRole)
 	for _, perm := range newACL.GroupPermissions {
 		groupPerms[perm.ID.ValueString()] = codersdk.TemplateRole(perm.Role.ValueString())
 	}
@@ -1598,7 +1600,6 @@ func tfVariablesChanged(prevs []PreviousTemplateVersion, planned *TemplateVersio
 		}
 	}
 	return true
-
 }
 
 func formatLogs(err error, logs []codersdk.ProvisionerJobLog) string {

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -636,6 +636,34 @@ func TestAccTemplateResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("InvalidMaxPortShareLevel", func(t *testing.T) {
+		cfg1 := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  ptr.Ref("example-template"),
+			Versions: []testAccTemplateVersionConfig{
+				{
+					Directory: &exTemplateOne,
+					Active:    ptr.Ref(true),
+				},
+			},
+			ACL:               testAccTemplateACLConfig{null: true},
+			MaxPortShareLevel: ptr.Ref("invalid"),
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      cfg1.String(t),
+					ExpectError: regexp.MustCompile(`value must be one of`),
+				},
+			},
+		})
+	})
 }
 
 func TestAccTemplateResourceEnterprise(t *testing.T) {
@@ -790,10 +818,10 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 		})
 	})
 
-	// Verifies that when `max_port_share_level` is set to to the default value,
-	// an update request that would return HTTP Not Modified is not sent.
-	t.Run("DefaultMaxPortShareLevel", func(t *testing.T) {
-		cfg1 := testAccTemplateResourceConfig{
+	// Verifies that all valid max_port_share_level constants are accepted and
+	// round-trip correctly through the API, including updates between values.
+	t.Run("MaxPortShareLevelConstants", func(t *testing.T) {
+		baseCfg := testAccTemplateResourceConfig{
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
@@ -803,8 +831,19 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 					Active:    ptr.Ref(true),
 				},
 			},
-			MaxPortShareLevel: ptr.Ref("owner"),
 		}
+
+		cfgOwner := baseCfg
+		cfgOwner.MaxPortShareLevel = ptr.Ref("owner")
+
+		cfgAuthenticated := baseCfg
+		cfgAuthenticated.MaxPortShareLevel = ptr.Ref("authenticated")
+
+		cfgOrganization := baseCfg
+		cfgOrganization.MaxPortShareLevel = ptr.Ref("organization")
+
+		cfgPublic := baseCfg
+		cfgPublic.MaxPortShareLevel = ptr.Ref("public")
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -812,8 +851,20 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: cfg1.String(t),
+					Config: cfgOwner.String(t),
 					Check:  resource.TestCheckResourceAttr("coderd_template.test", "max_port_share_level", "owner"),
+				},
+				{
+					Config: cfgAuthenticated.String(t),
+					Check:  resource.TestCheckResourceAttr("coderd_template.test", "max_port_share_level", "authenticated"),
+				},
+				{
+					Config: cfgOrganization.String(t),
+					Check:  resource.TestCheckResourceAttr("coderd_template.test", "max_port_share_level", "organization"),
+				},
+				{
+					Config: cfgPublic.String(t),
+					Check:  resource.TestCheckResourceAttr("coderd_template.test", "max_port_share_level", "public"),
 				},
 			},
 		})
@@ -1595,7 +1646,6 @@ func TestReconcileVersionIDs(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1606,6 +1656,5 @@ func TestReconcileVersionIDs(t *testing.T) {
 				require.Equal(t, c.expectedVersions, c.planVersions)
 			}
 		})
-
 	}
 }


### PR DESCRIPTION
Add missing `Organization` option for workspace sharing