### PR TITLE
fix: preserve sensitive tf_vars and unknown version names

### DIFF
--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -1049,39 +1049,39 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		return
 	}
 
-    // Now patch the original plan elements with only the fields we changed
-    planElements := req.PlanValue.Elements()
-    newElements := make([]attr.Value, len(planElements))
+	// Now patch the original plan elements with only the fields we changed
+	planElements := req.PlanValue.Elements()
+	newElements := make([]attr.Value, len(planElements))
 
-    for i, elem := range planElements {
-        obj, ok := elem.(types.Object)
-        if !ok {
-            resp.Diagnostics.AddError("Client Error", "Expected object element in versions list")
-            return
-        }
+	for i, elem := range planElements {
+		obj, ok := elem.(types.Object)
+		if !ok {
+			resp.Diagnostics.AddError("Client Error", "Expected object element in versions list")
+			return
+		}
 
-        attrs := obj.Attributes()
-        attrTypes := obj.AttributeTypes(ctx)
+		attrs := obj.Attributes()
+		attrTypes := obj.AttributeTypes(ctx)
 
-        // Overwrite only the fields the plan modifier manages
-        attrs["id"] = planVersions[i].ID
-        attrs["name"] = planVersions[i].Name
-        attrs["directory_hash"] = planVersions[i].DirectoryHash
+		// Overwrite only the fields the plan modifier manages
+		attrs["id"] = planVersions[i].ID
+		attrs["name"] = planVersions[i].Name
+		attrs["directory_hash"] = planVersions[i].DirectoryHash
 
-        // tf_vars, provisioner_tags, directory, active, message — all untouched
+		// tf_vars, provisioner_tags, directory, active, message — all untouched
 
-        newObj, objDiag := types.ObjectValue(attrTypes, attrs)
-        if objDiag.HasError() {
-            resp.Diagnostics.Append(objDiag...)
-            return
-        }
-        newElements[i] = newObj
-    }
+		newObj, objDiag := types.ObjectValue(attrTypes, attrs)
+		if objDiag.HasError() {
+			resp.Diagnostics.Append(objDiag...)
+			return
+		}
+		newElements[i] = newObj
+	}
 
-    resp.PlanValue, diag = types.ListValue(req.PlanValue.ElementType(ctx), newElements)
-    if diag.HasError() {
-        resp.Diagnostics.Append(diag...)
-    }
+	resp.PlanValue, diag = types.ListValue(req.PlanValue.ElementType(ctx), newElements)
+	if diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+	}
 }
 
 func hasOneActiveVersion(data Versions) (hasActiveVersion bool, diags diag.Diagnostics) {

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -1546,7 +1546,7 @@ func (planVersions Versions) reconcileVersionIDs(lv LastVersionsByHash, configVe
 		prevList := lv[planVersions[i].DirectoryHash.ValueString()]
 		if len(prevList) > 0 && planVersions[i].ID.IsUnknown() {
 			planVersions[i].ID = UUIDValue(prevList[0].ID)
-			if planVersions[i].Name.IsNull() {
+			if configVersions[i].Name.IsNull() {
 				planVersions[i].Name = types.StringValue(prevList[0].Name)
 			}
 			lv[planVersions[i].DirectoryHash.ValueString()] = prevList[1:]

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -1049,7 +1049,12 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		return
 	}
 
-	// Now patch the original plan elements with only the fields we changed
+	// Patch the original plan elements instead of rebuilding the entire list
+	// from planVersions. Re-encoding the whole list with ListValueFrom() strips
+	// Terraform Core's cty-level marks from nested values (for example sensitive
+	// tf_vars entries), which can surface later as an inconsistent final plan
+	// during deferred re-plans. Keeping the original attr.Values intact preserves
+	// those marks on untouched fields.
 	planElements := req.PlanValue.Elements()
 	newElements := make([]attr.Value, len(planElements))
 
@@ -1060,6 +1065,8 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 			return
 		}
 
+		// types.Object.Attributes returns a copy of the attribute map, so it is
+		// safe to mutate attrs before constructing the replacement object.
 		attrs := obj.Attributes()
 		attrTypes := obj.AttributeTypes(ctx)
 

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -1049,10 +1049,39 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		return
 	}
 
-	resp.PlanValue, diag = types.ListValueFrom(ctx, req.PlanValue.ElementType(ctx), planVersions)
-	if diag.HasError() {
-		resp.Diagnostics.Append(diag...)
-	}
+    // Now patch the original plan elements with only the fields we changed
+    planElements := req.PlanValue.Elements()
+    newElements := make([]attr.Value, len(planElements))
+
+    for i, elem := range planElements {
+        obj, ok := elem.(types.Object)
+        if !ok {
+            resp.Diagnostics.AddError("Client Error", "Expected object element in versions list")
+            return
+        }
+
+        attrs := obj.Attributes()
+        attrTypes := obj.AttributeTypes(ctx)
+
+        // Overwrite only the fields the plan modifier manages
+        attrs["id"] = planVersions[i].ID
+        attrs["name"] = planVersions[i].Name
+        attrs["directory_hash"] = planVersions[i].DirectoryHash
+
+        // tf_vars, provisioner_tags, directory, active, message — all untouched
+
+        newObj, objDiag := types.ObjectValue(attrTypes, attrs)
+        if objDiag.HasError() {
+            resp.Diagnostics.Append(objDiag...)
+            return
+        }
+        newElements[i] = newObj
+    }
+
+    resp.PlanValue, diag = types.ListValue(req.PlanValue.ElementType(ctx), newElements)
+    if diag.HasError() {
+        resp.Diagnostics.Append(diag...)
+    }
 }
 
 func hasOneActiveVersion(data Versions) (hasActiveVersion bool, diags diag.Diagnostics) {
@@ -1517,7 +1546,7 @@ func (planVersions Versions) reconcileVersionIDs(lv LastVersionsByHash, configVe
 		prevList := lv[planVersions[i].DirectoryHash.ValueString()]
 		if len(prevList) > 0 && planVersions[i].ID.IsUnknown() {
 			planVersions[i].ID = UUIDValue(prevList[0].ID)
-			if planVersions[i].Name.IsUnknown() {
+			if planVersions[i].Name.IsNull() {
 				planVersions[i].Name = types.StringValue(prevList[0].Name)
 			}
 			lv[planVersions[i].DirectoryHash.ValueString()] = prevList[1:]

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -1019,6 +1019,102 @@ resource "coderd_template" "sample" {
 	})
 }
 
+func TestAccTemplateResourceSensitiveTFVarsDeferredReplan(t *testing.T) {
+	t.Parallel()
+
+	// Changing the sensitive tf_var forces random_uuid to be replaced, which
+	// makes the version name unknown during planning and triggers a deferred
+	// re-plan during apply. Before PlanModifyList started patching the original
+	// attr.Values instead of rebuilding the whole list, this failed with:
+	// "Provider produced inconsistent final plan ... inconsistent values for
+	// sensitive attribute".
+	cfg := `
+provider coderd {
+	url   = %q
+	token = %q
+}
+
+variable "secret_one" {
+	type      = string
+	sensitive = true
+	default   = %q
+}
+
+locals {
+	my_secrets = {
+		normal = "hi"
+		secret = var.secret_one
+	}
+}
+
+resource "random_uuid" "uuid" {
+	keepers = local.my_secrets
+}
+
+resource "coderd_template" "test" {
+	name = "sensitive-template"
+
+	versions = [{
+		name      = random_uuid.uuid.result
+		directory = %q
+		active    = true
+		tf_vars = [for k, v in local.my_secrets : {
+			name  = k
+			value = tostring(v)
+		}]
+	}]
+}
+`
+
+	ctx := t.Context()
+	client := integration.StartCoder(ctx, t, "template_resource_sensitive_tfvars_acc")
+
+	exTemplateOne := t.TempDir()
+	err := cp.Copy("../../integration/template-test/example-template", exTemplateOne)
+	require.NoError(t, err)
+
+	cfg1 := fmt.Sprintf(cfg, client.URL.String(), client.SessionToken(), "no", exTemplateOne)
+	cfg2 := fmt.Sprintf(cfg, client.URL.String(), client.SessionToken(), "yes", exTemplateOne)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "~> 3.7",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: cfg1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
+					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+						"name":           regexp.MustCompile(".+"),
+						"id":             regexp.MustCompile(".+"),
+						"directory_hash": regexp.MustCompile(".+"),
+					}),
+					testAccCheckNumTemplateVersions(ctx, client, 1),
+				),
+			},
+			{
+				Config: cfg2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
+					resource.TestMatchTypeSetElemNestedAttrs("coderd_template.test", "versions.*", map[string]*regexp.Regexp{
+						"name":           regexp.MustCompile(".+"),
+						"id":             regexp.MustCompile(".+"),
+						"directory_hash": regexp.MustCompile(".+"),
+					}),
+					testAccCheckNumTemplateVersions(ctx, client, 2),
+				),
+			},
+		},
+	})
+}
+
 type testAccTemplateResourceConfig struct {
 	URL   string
 	Token string

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -1388,7 +1388,65 @@ func TestReconcileVersionIDs(t *testing.T) {
 			},
 		},
 		{
+			// Config name is null (auto-generated), plan name is unknown.
+			// Should backfill name from state since the user didn't set one.
 			Name: "UnknownUsesStateInOrder",
+			planVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 NewUUIDUnknown(),
+					TerraformVariables: []Variable{},
+				},
+				{
+					Name:               types.StringUnknown(),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 NewUUIDUnknown(),
+					TerraformVariables: []Variable{},
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+				{
+					Name: types.StringNull(),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:     aUUID,
+						Name:   "qux",
+						TFVars: map[string]string{},
+					},
+					{
+						ID:     bUUID,
+						Name:   "baz",
+						TFVars: map[string]string{},
+					},
+				},
+			},
+			expectedVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 UUIDValue(aUUID),
+					TerraformVariables: []Variable{},
+				},
+				{
+					Name:               types.StringValue("baz"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 UUIDValue(bUUID),
+					TerraformVariables: []Variable{},
+				},
+			},
+		},
+		{
+			// Config name is non-null (e.g. random_uuid.result), plan name is unknown
+			// because the upstream resource is being recreated.
+			// Should NOT backfill name — leave it unknown to resolve after apply.
+			Name: "UnknownNonNullConfigNameNotBackfilled",
 			planVersions: []TemplateVersion{
 				{
 					Name:               types.StringValue("foo"),
@@ -1433,7 +1491,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 					TerraformVariables: []Variable{},
 				},
 				{
-					Name:               types.StringValue("baz"),
+					Name:               types.StringUnknown(),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(bUUID),
 					TerraformVariables: []Variable{},

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	cp "github.com/otiai10/copy"
 	"github.com/stretchr/testify/require"
 
@@ -1077,8 +1078,14 @@ resource "coderd_template" "test" {
 	cfg2 := fmt.Sprintf(cfg, client.URL.String(), client.SessionToken(), "yes", exTemplateOne)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		IsUnitTest:               true,
+		PreCheck:   func() { testAccPreCheck(t) },
+		IsUnitTest: true,
+		// Terraform 1.0 panics while formatting plans that contain marked nested
+		// values in this scenario ("value is marked, so must be unmarked first").
+		// The provider regression is still covered on Terraform 1.1+.
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_1_0),
+		},
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {


### PR DESCRIPTION
This keeps template version plan updates from rewriting unrelated nested values, which preserves sensitive tf_vars during deferred replans. It also stops reusing a previous version name when the config supplied a non-null expression that is still unknown at plan time, like a random_uuid result. The change adds regressions for both cases and skips the sensitive tf_vars acceptance test on Terraform 1.0, where the CLI panics while formatting that plan.