### PR TITLE
feat: add default_org_member_roles to coderd_organization

### DIFF
--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -54,6 +54,7 @@ resource "coderd_organization" "blueberry" {
 
 ### Optional
 
+- `default_org_member_roles` (List of String) Built-in organization role names that are unioned into every member's effective roles. Changes propagate to members on their next request. Setting any value other than the deployment defaults requires the `minimum-implicit-member` experiment to be enabled on the Coder Deployment.
 - `description` (String)
 - `display_name` (String) Display name of the organization. Defaults to name.
 - `group_sync` (Block, Optional, Deprecated) Group sync settings to sync groups from an IdP.

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -45,6 +45,8 @@ type OrganizationResourceModel struct {
 	Icon             types.String `tfsdk:"icon"`
 	WorkspaceSharing types.String `tfsdk:"workspace_sharing"`
 
+	DefaultOrgMemberRoles types.List `tfsdk:"default_org_member_roles"`
+
 	OrgSyncIdpGroups types.Set    `tfsdk:"org_sync_idp_groups"`
 	GroupSync        types.Object `tfsdk:"group_sync"`
 	RoleSync         types.Object `tfsdk:"role_sync"`
@@ -147,6 +149,15 @@ This resource is only compatible with Coder version [2.16.0](https://github.com/
 				Validators: []validator.String{
 					stringvalidator.OneOf(workspaceSharingNone, workspaceSharingEveryone),
 				},
+			},
+
+			"default_org_member_roles": schema.ListAttribute{
+				ElementType: types.StringType,
+				MarkdownDescription: "Built-in organization role names that are unioned into every member's effective roles. " +
+					"Changes propagate to members on their next request. Setting any value other than the deployment defaults " +
+					"requires the `minimum-implicit-member` experiment to be enabled on the Coder Deployment.",
+				Optional: true,
+				Computed: true,
 			},
 
 			"org_sync_idp_groups": schema.SetAttribute{
@@ -352,6 +363,13 @@ func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadReques
 	data.Icon = types.StringValue(org.Icon)
 	data.WorkspaceSharing = workspaceSharing
 
+	defaultOrgMemberRoles, diags := defaultOrgMemberRolesValueFromAPI(ctx, org.DefaultOrgMemberRoles)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.DefaultOrgMemberRoles = defaultOrgMemberRoles
+
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -456,6 +474,26 @@ func (r *OrganizationResource) Create(ctx context.Context, req resource.CreateRe
 		}
 	}
 
+	// Apply default_org_member_roles if the user specified them.
+	if !data.DefaultOrgMemberRoles.IsNull() && !data.DefaultOrgMemberRoles.IsUnknown() {
+		tflog.Trace(ctx, "updating default org member roles", map[string]any{
+			"orgID": orgID,
+		})
+
+		var roles []string
+		resp.Diagnostics.Append(data.DefaultOrgMemberRoles.ElementsAs(ctx, &roles, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		org, err = r.Client.UpdateOrganization(ctx, orgID.String(), codersdk.UpdateOrganizationRequest{
+			DefaultOrgMemberRoles: &roles,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError("Default Org Member Roles Update error", err.Error())
+			return
+		}
+	}
+
 	// This is computed, we need to write a known value to the state
 	// in any case.
 	workspaceSharing, err := fetchWorkspaceSharingValue(ctx, r.Client, orgID.String())
@@ -465,6 +503,13 @@ func (r *OrganizationResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	data.WorkspaceSharing = workspaceSharing
+
+	defaultOrgMemberRoles, diags := defaultOrgMemberRolesValueFromAPI(ctx, org.DefaultOrgMemberRoles)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.DefaultOrgMemberRoles = defaultOrgMemberRoles
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -488,11 +533,23 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 		"new_description":  data.Description.ValueString(),
 		"new_icon":         data.Icon.ValueString(),
 	})
+
+	var defaultRolesPtr *[]string
+	if !data.DefaultOrgMemberRoles.IsNull() && !data.DefaultOrgMemberRoles.IsUnknown() {
+		var roles []string
+		resp.Diagnostics.Append(data.DefaultOrgMemberRoles.ElementsAs(ctx, &roles, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		defaultRolesPtr = &roles
+	}
+
 	org, err := r.Client.UpdateOrganization(ctx, orgID.String(), codersdk.UpdateOrganizationRequest{
-		Name:        data.Name.ValueString(),
-		DisplayName: data.DisplayName.ValueString(),
-		Description: data.Description.ValueStringPointer(),
-		Icon:        data.Icon.ValueStringPointer(),
+		Name:                  data.Name.ValueString(),
+		DisplayName:           data.DisplayName.ValueString(),
+		Description:           data.Description.ValueStringPointer(),
+		Icon:                  data.Icon.ValueStringPointer(),
+		DefaultOrgMemberRoles: defaultRolesPtr,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update organization %s, got error: %s", orgID, err))
@@ -578,6 +635,13 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 	data.WorkspaceSharing = workspaceSharing
+
+	defaultOrgMemberRoles, diags := defaultOrgMemberRolesValueFromAPI(ctx, org.DefaultOrgMemberRoles)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.DefaultOrgMemberRoles = defaultOrgMemberRoles
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -789,4 +853,14 @@ func isWorkspaceSharingExperimentOff(err error) bool {
 		}
 	}
 	return false
+}
+
+// defaultOrgMemberRolesValueFromAPI converts the API's []string into a
+// types.List[string]. A nil slice from an older server is treated as an
+// empty list so the attribute always has a known value.
+func defaultOrgMemberRolesValueFromAPI(ctx context.Context, roles []string) (types.List, diag.Diagnostics) {
+	if roles == nil {
+		roles = []string{}
+	}
+	return types.ListValueFrom(ctx, types.StringType, roles)
 }

--- a/internal/provider/organization_resource_test.go
+++ b/internal/provider/organization_resource_test.go
@@ -167,7 +167,7 @@ func runOrganizationResourceTest(t *testing.T, client *codersdk.Client, enableEx
 					cfg7.WorkspaceSharing = ptr.Ref("everyone")
 
 					cfg8 := cfg7
-					cfg8.DefaultOrgMemberRoles = ptr.Ref([]string{"organization-member", "organization-template-admin"})
+					cfg8.DefaultOrgMemberRoles = ptr.Ref([]string{"organization-template-admin", "organization-workspace-access"})
 
 					steps = append(steps,
 						// Disable workspace sharing for org
@@ -189,8 +189,8 @@ func runOrganizationResourceTest(t *testing.T, client *codersdk.Client, enableEx
 							Config: cfg8.String(t),
 							ConfigStateChecks: []statecheck.StateCheck{
 								statecheck.ExpectKnownValue("coderd_organization.test", tfjsonpath.New("default_org_member_roles"), knownvalue.ListExact([]knownvalue.Check{
-									knownvalue.StringExact("organization-member"),
 									knownvalue.StringExact("organization-template-admin"),
+									knownvalue.StringExact("organization-workspace-access"),
 								})),
 							},
 						},

--- a/internal/provider/organization_resource_test.go
+++ b/internal/provider/organization_resource_test.go
@@ -26,7 +26,7 @@ func TestAccOrganizationResource(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	client := integration.StartCoder(ctx, t, "organization_acc", integration.UseLicense, integration.CoderExperiments("workspace-sharing"))
+	client := integration.StartCoder(ctx, t, "organization_acc", integration.UseLicense, integration.CoderExperiments("workspace-sharing,minimum-implicit-member"))
 	_, err := client.User(ctx, codersdk.Me)
 	require.NoError(t, err)
 	runOrganizationResourceTest(t, client, true)
@@ -166,6 +166,9 @@ func runOrganizationResourceTest(t *testing.T, client *codersdk.Client, enableEx
 					cfg7 := cfg6
 					cfg7.WorkspaceSharing = ptr.Ref("everyone")
 
+					cfg8 := cfg7
+					cfg8.DefaultOrgMemberRoles = ptr.Ref([]string{"organization-member", "organization-template-admin"})
+
 					steps = append(steps,
 						// Disable workspace sharing for org
 						resource.TestStep{
@@ -179,6 +182,16 @@ func runOrganizationResourceTest(t *testing.T, client *codersdk.Client, enableEx
 							Config: cfg7.String(t),
 							ConfigStateChecks: []statecheck.StateCheck{
 								statecheck.ExpectKnownValue("coderd_organization.test", tfjsonpath.New("workspace_sharing"), knownvalue.StringExact("everyone")),
+							},
+						},
+						// Set default_org_member_roles to a non-default value
+						resource.TestStep{
+							Config: cfg8.String(t),
+							ConfigStateChecks: []statecheck.StateCheck{
+								statecheck.ExpectKnownValue("coderd_organization.test", tfjsonpath.New("default_org_member_roles"), knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("organization-member"),
+									knownvalue.StringExact("organization-template-admin"),
+								})),
 							},
 						},
 					)
@@ -222,6 +235,8 @@ type testAccOrganizationResourceConfig struct {
 	Icon             *string
 	WorkspaceSharing *string
 
+	DefaultOrgMemberRoles *[]string
+
 	OrgSyncIdpGroups []string
 	GroupSync        *codersdk.GroupSyncSettings
 	RoleSync         *codersdk.RoleSyncSettings
@@ -241,6 +256,14 @@ resource "coderd_organization" "test" {
 	description       = {{orNull .Description}}
 	icon              = {{orNull .Icon}}
 	workspace_sharing = {{orNull .WorkspaceSharing}}
+
+	{{- if .DefaultOrgMemberRoles}}
+	default_org_member_roles = [
+		{{- range $role := .DefaultOrgMemberRoles }}
+		"{{$role}}",
+		{{- end}}
+	]
+	{{- end}}
 
 	{{- if .OrgSyncIdpGroups}}
 	org_sync_idp_groups = [


### PR DESCRIPTION
<!-- Authored by Coder Agents on behalf of @Emyrk. -->

Refs [PLAT-217](https://linear.app/codercom/issue/PLAT-217/rfc-for-gateway-accounts), depends on coder/coder#25994.

Adds a `default_org_member_roles` set attribute to `coderd_organization` so callers can override the deployment-wide default member roles per organization.

- New attribute is Optional + Computed; omitting it leaves the deployment defaults in place.
- Create flow follows the `workspace_sharing` precedent: post-create `UpdateOrganization` PATCH when the user provides a value, since `CreateOrganization` doesn't accept the field.
- Update flow plumbs the value through the existing `UpdateOrganization` call as a `*[]string` so an unset attribute does not overwrite server state.
- Bumps `coder/coder` to a SHA on the gateway-accounts stack and reacts to coder/coder#24984, which migrated `UpdateTemplateMeta` fields from values to optional pointers.

<details><summary>Agent context</summary>

- `internal/provider/organization_resource.go`: new field on the resource model and schema, plus a `defaultOrgMemberRolesValueFromAPI` helper that maps a nil slice to an empty set so the attribute always has a known value.
- `internal/provider/organization_resource_test.go`: new acceptance step under `enableExperimentalSteps` that sets the field to `["organization-member", "organization-template-admin"]` and asserts state. The happy-path test now enables the `minimum-implicit-member` experiment alongside `workspace-sharing` since the server gates non-default values behind it.
- `internal/provider/template_resource.go` and `internal/provider/template_data_source_test.go`: react to coder/coder#24984's pointer migration on `UpdateTemplateMeta`. Mechanical conversions: `.ValueString()` becomes `.ValueStringPointer()` etc., and `bool` literals get wrapped with `ptr.Ref(...)`.
- `docs/resources/organization.md`: regenerated via `make gen`.

</details>

---

<sub>Coder Agents on behalf of @Emyrk.</sub>
