### PR TITLE
fix: handle unknown tf_vars and provisioner_tags at plan time

### DIFF
--- a/internal/provider/template_data_source_test.go
+++ b/internal/provider/template_data_source_test.go
@@ -35,12 +35,12 @@ func TestAccTemplateDataSource(t *testing.T) {
 			Name:      types.StringValue("main"),
 			Message:   types.StringValue("Initial commit"),
 			Directory: types.StringValue("../../integration/template-test/example-template/"),
-			TerraformVariables: []Variable{
+			TerraformVariables: mustVariablesToSet([]Variable{
 				{
 					Name:  types.StringValue("name"),
 					Value: types.StringValue("world"),
 				},
-			},
+			}),
 		},
 	})
 	require.NoError(t, err)

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -165,8 +165,8 @@ type TemplateVersion struct {
 	Directory          types.String `tfsdk:"directory"`
 	DirectoryHash      types.String `tfsdk:"directory_hash"`
 	Active             types.Bool   `tfsdk:"active"`
-	TerraformVariables []Variable   `tfsdk:"tf_vars"`
-	ProvisionerTags    []Variable   `tfsdk:"provisioner_tags"`
+	TerraformVariables types.Set    `tfsdk:"tf_vars"`
+	ProvisionerTags    types.Set    `tfsdk:"provisioner_tags"`
 }
 
 type Versions []TemplateVersion
@@ -194,6 +194,41 @@ var variableNestedObject = schema.NestedAttributeObject{
 			Required: true,
 		},
 	},
+}
+
+// variableSetElemType is the attr.Type for each element in a Set of Variable.
+var variableSetElemType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.StringType,
+	},
+}
+
+// variablesFromSet extracts a []Variable from a types.Set. It returns nil when
+// the set is null or unknown, so callers must treat those states as "no known
+// variables" rather than relying on the slice contents.
+func variablesFromSet(ctx context.Context, s types.Set) ([]Variable, diag.Diagnostics) {
+	if s.IsNull() || s.IsUnknown() {
+		return nil, nil
+	}
+	var vars []Variable
+	diags := s.ElementsAs(ctx, &vars, false)
+	return vars, diags
+}
+
+// variablesToSet converts a []Variable into a types.Set. A nil slice becomes a
+// null set so it round-trips through variablesFromSet.
+func variablesToSet(ctx context.Context, vars []Variable) (types.Set, diag.Diagnostics) {
+	if vars == nil {
+		return types.SetNull(variableSetElemType), nil
+	}
+	return types.SetValueFrom(ctx, variableSetElemType, vars)
+}
+
+// emptyVariableSet returns an empty (non-null, known) types.Set with the
+// correct element type.
+func emptyVariableSet() types.Set {
+	return types.SetValueMust(variableSetElemType, []attr.Value{})
 }
 
 type ACL struct {
@@ -1237,14 +1272,22 @@ func newVersion(ctx context.Context, client *codersdk.Client, req newVersionRequ
 	tflog.Info(ctx, "discovered and parsed vars files", map[string]any{
 		"vars": vars,
 	})
-	for _, variable := range req.Version.TerraformVariables {
+	tfVars, diags := variablesFromSet(ctx, req.Version.TerraformVariables)
+	if diags.HasError() {
+		return nil, logs, fmt.Errorf("failed to extract terraform variables: %s", diags.Errors()[0].Detail())
+	}
+	for _, variable := range tfVars {
 		vars = append(vars, codersdk.VariableValue{
 			Name:  variable.Name.ValueString(),
 			Value: variable.Value.ValueString(),
 		})
 	}
-	provTags := make(map[string]string, len(req.Version.ProvisionerTags))
-	for _, provisionerTag := range req.Version.ProvisionerTags {
+	provTagVars, diags := variablesFromSet(ctx, req.Version.ProvisionerTags)
+	if diags.HasError() {
+		return nil, logs, fmt.Errorf("failed to extract provisioner tags: %s", diags.Errors()[0].Detail())
+	}
+	provTags := make(map[string]string, len(provTagVars))
+	for _, provisionerTag := range provTagVars {
 		provTags[provisionerTag.Name.ValueString()] = provisionerTag.Value.ValueString()
 	}
 	tmplVerReq := codersdk.CreateTemplateVersionRequest{
@@ -1482,8 +1525,13 @@ func (v Versions) setPrivateState(ctx context.Context, ps privateState) (diags d
 	lv := make(LastVersionsByHash)
 	for _, version := range v {
 		vbh, ok := lv[version.DirectoryHash.ValueString()]
-		tfVars := make(map[string]string, len(version.TerraformVariables))
-		for _, tfVar := range version.TerraformVariables {
+		versionTfVars, varDiags := variablesFromSet(ctx, version.TerraformVariables)
+		if varDiags.HasError() {
+			diags.Append(varDiags...)
+			return diags
+		}
+		tfVars := make(map[string]string, len(versionTfVars))
+		for _, tfVar := range versionTfVars {
 			tfVars[tfVar.Name.ValueString()] = tfVar.Value.ValueString()
 		}
 		// Store the IDs and names of all versions with the same directory hash,
@@ -1627,7 +1675,13 @@ func tfVariablesChanged(prevs []PreviousTemplateVersion, planned *TemplateVersio
 			if prev.TFVars == nil {
 				return true
 			}
-			for _, tfVar := range planned.TerraformVariables {
+			// If the planned set is unknown we cannot compare values, so assume
+			// the variables changed and let a new version be created.
+			if planned.TerraformVariables.IsUnknown() {
+				return true
+			}
+			plannedVars, _ := variablesFromSet(context.Background(), planned.TerraformVariables)
+			for _, tfVar := range plannedVars {
 				if prev.TFVars[tfVar.Name.ValueString()] != tfVar.Value.ValueString() {
 					return true
 				}

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -1680,7 +1680,18 @@ func tfVariablesChanged(prevs []PreviousTemplateVersion, planned *TemplateVersio
 			if planned.TerraformVariables.IsUnknown() {
 				return true
 			}
-			plannedVars, _ := variablesFromSet(context.Background(), planned.TerraformVariables)
+			plannedVars, diags := variablesFromSet(context.Background(), planned.TerraformVariables)
+			// If we can't decode the planned variables, fail toward creating a
+			// new version rather than silently reusing a stale one.
+			if diags.HasError() {
+				return true
+			}
+			// A subset comparison alone would miss removed variables (a planned
+			// strict subset of prev passes every check), so compare counts
+			// first. This also covers a null set: nil plannedVars has len 0.
+			if len(plannedVars) != len(prev.TFVars) {
+				return true
+			}
 			for _, tfVar := range plannedVars {
 				if prev.TFVars[tfVar.Name.ValueString()] != tfVar.Value.ValueString() {
 					return true

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -11,6 +11,8 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -22,6 +24,16 @@ import (
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/coder/terraform-provider-coderd/integration"
 )
+
+// mustVariablesToSet converts a []Variable to a types.Set for use in tests,
+// panicking if the conversion fails.
+func mustVariablesToSet(vars []Variable) types.Set {
+	s, diags := variablesToSet(context.Background(), vars)
+	if diags.HasError() {
+		panic(fmt.Sprintf("mustVariablesToSet: %v", diags.Errors()))
+	}
+	return s
+}
 
 func TestAccTemplateResource(t *testing.T) {
 	t.Parallel()
@@ -1399,13 +1411,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1430,13 +1442,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1447,13 +1459,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1478,13 +1490,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1495,13 +1507,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1531,13 +1543,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("bar"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(bUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1550,13 +1562,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringUnknown(),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1586,13 +1598,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringValue("baz"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(bUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1606,13 +1618,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringUnknown(),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1642,13 +1654,13 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 				{
 					Name:               types.StringUnknown(),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 UUIDValue(bUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1659,7 +1671,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("weird_draught12"),
 					DirectoryHash:      types.StringValue("bbb"),
 					ID:                 UUIDValue(aUUID),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1681,7 +1693,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringUnknown(),
 					DirectoryHash:      types.StringValue("bbb"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 				},
 			},
 		},
@@ -1692,12 +1704,12 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            UUIDValue(aUUID),
-					TerraformVariables: []Variable{
+					TerraformVariables: mustVariablesToSet([]Variable{
 						{
 							Name:  types.StringValue("foo"),
 							Value: types.StringValue("bar"),
 						},
-					},
+					}),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1721,12 +1733,12 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            NewUUIDUnknown(),
-					TerraformVariables: []Variable{
+					TerraformVariables: mustVariablesToSet([]Variable{
 						{
 							Name:  types.StringValue("foo"),
 							Value: types.StringValue("bar"),
 						},
-					},
+					}),
 				},
 			},
 		},
@@ -1737,12 +1749,12 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            UUIDValue(aUUID),
-					TerraformVariables: []Variable{
+					TerraformVariables: mustVariablesToSet([]Variable{
 						{
 							Name:  types.StringValue("foo"),
 							Value: types.StringValue("bar"),
 						},
-					},
+					}),
 				},
 			},
 			configVersions: []TemplateVersion{
@@ -1766,12 +1778,12 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:          types.StringValue("foo"),
 					DirectoryHash: types.StringValue("aaa"),
 					ID:            UUIDValue(aUUID),
-					TerraformVariables: []Variable{
+					TerraformVariables: mustVariablesToSet([]Variable{
 						{
 							Name:  types.StringValue("foo"),
 							Value: types.StringValue("bar"),
 						},
-					},
+					}),
 				},
 			},
 		},
@@ -1782,7 +1794,7 @@ func TestReconcileVersionIDs(t *testing.T) {
 					Name:               types.StringValue("foo"),
 					DirectoryHash:      types.StringValue("aaa"),
 					ID:                 NewUUIDUnknown(),
-					TerraformVariables: []Variable{},
+					TerraformVariables: emptyVariableSet(),
 					Active:             types.BoolValue(false),
 				},
 			},
@@ -1804,6 +1816,76 @@ func TestReconcileVersionIDs(t *testing.T) {
 			cfgHasActiveVersion: false,
 			expectError:         true,
 		},
+		{
+			Name: "UnknownTFVarsHandled",
+			planVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 UUIDValue(aUUID),
+					TerraformVariables: types.SetUnknown(variableSetElemType),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:     aUUID,
+						Name:   "foo",
+						TFVars: map[string]string{"x": "y"},
+					},
+				},
+			},
+			// An unknown tf_vars set cannot be compared against the prior state,
+			// so a new version is created (ID becomes unknown).
+			expectedVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 NewUUIDUnknown(),
+					TerraformVariables: types.SetUnknown(variableSetElemType),
+				},
+			},
+		},
+		{
+			Name: "NullTFVarsHandled",
+			planVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 UUIDValue(aUUID),
+					TerraformVariables: types.SetNull(variableSetElemType),
+				},
+			},
+			configVersions: []TemplateVersion{
+				{
+					Name: types.StringValue("foo"),
+				},
+			},
+			inputState: map[string][]PreviousTemplateVersion{
+				"aaa": {
+					{
+						ID:     aUUID,
+						Name:   "foo",
+						TFVars: map[string]string{},
+					},
+				},
+			},
+			// A null tf_vars set is treated as no variables, so the existing
+			// version is reused without error.
+			expectedVersions: []TemplateVersion{
+				{
+					Name:               types.StringValue("foo"),
+					DirectoryHash:      types.StringValue("aaa"),
+					ID:                 UUIDValue(aUUID),
+					TerraformVariables: types.SetNull(variableSetElemType),
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -1818,4 +1900,158 @@ func TestReconcileVersionIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// versionObjectType returns the attr.Type for a single element of the versions
+// list attribute, matching the resource schema. It is shared by the regression
+// tests for issue #305.
+func versionObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"id":             UUIDType,
+			"name":           types.StringType,
+			"message":        types.StringType,
+			"directory":      types.StringType,
+			"directory_hash": types.StringType,
+			"active":         types.BoolType,
+			"tf_vars": types.SetType{
+				ElemType: variableSetElemType,
+			},
+			"provisioner_tags": types.SetType{
+				ElemType: variableSetElemType,
+			},
+		},
+	}
+}
+
+// TestValidateListUnknownTFVars reproduces issue #305: when tf_vars or
+// provisioner_tags are derived from variables that are unknown at validate
+// time, ValidateResourceConfig invokes the list validator with an unknown set
+// element. With []Variable fields ElementsAs could not decode an unknown set
+// into a native slice and returned a "Value Conversion Error". With types.Set
+// fields the validator must succeed without diagnostics.
+func TestValidateListUnknownTFVars(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	objType := versionObjectType()
+
+	versionVal, diags := types.ObjectValue(objType.AttrTypes, map[string]attr.Value{
+		"id":               NewUUIDUnknown(),
+		"name":             types.StringValue("main"),
+		"message":          types.StringValue(""),
+		"directory":        types.StringValue("./template"),
+		"directory_hash":   types.StringUnknown(),
+		"active":           types.BoolValue(true),
+		"tf_vars":          types.SetUnknown(variableSetElemType),
+		"provisioner_tags": types.SetUnknown(variableSetElemType),
+	})
+	require.False(t, diags.HasError(), "building version object: %v", diags.Errors())
+
+	listVal, diags := types.ListValue(objType, []attr.Value{versionVal})
+	require.False(t, diags.HasError(), "building list: %v", diags.Errors())
+
+	resp := &validator.ListResponse{}
+	NewVersionsValidator().ValidateList(ctx, validator.ListRequest{
+		ConfigValue: listVal,
+	}, resp)
+	require.False(t, resp.Diagnostics.HasError(),
+		"ValidateList must accept unknown tf_vars: %v", resp.Diagnostics.Errors())
+}
+
+// TestUnknownTFVarsDeserialization validates that a TemplateVersion can be
+// decoded from a types.List even when tf_vars or provisioner_tags contain
+// unknown or null values. This is the exact ElementsAs code path that failed
+// in issue #305 when tf_vars came from a for-expression over variables with
+// sensitive or unknown values.
+func TestUnknownTFVarsDeserialization(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	objType := versionObjectType()
+
+	// buildAndDeserialize wraps a single version object (with the given tf_vars
+	// and provisioner_tags values) in a list and decodes it into
+	// []TemplateVersion, asserting that ElementsAs succeeds.
+	buildAndDeserialize := func(t *testing.T, tfVars, provTags attr.Value) []TemplateVersion {
+		t.Helper()
+		obj, d := types.ObjectValue(objType.AttrTypes, map[string]attr.Value{
+			"id":               NewUUIDUnknown(),
+			"name":             types.StringValue("stable-1"),
+			"message":          types.StringValue(""),
+			"directory":        types.StringValue("/tmp/test"),
+			"directory_hash":   types.StringUnknown(),
+			"active":           types.BoolValue(true),
+			"tf_vars":          tfVars,
+			"provisioner_tags": provTags,
+		})
+		require.False(t, d.HasError(), "building version object: %v", d.Errors())
+		lv, d := types.ListValue(objType, []attr.Value{obj})
+		require.False(t, d.HasError(), "building list: %v", d.Errors())
+		var result []TemplateVersion
+		d = lv.ElementsAs(ctx, &result, false)
+		require.False(t, d.HasError(), "ElementsAs failed: %v", d.Errors())
+		require.Len(t, result, 1)
+		return result
+	}
+
+	knownVarSet := mustVariablesToSet([]Variable{
+		{Name: types.StringValue("secret-1"), Value: types.StringValue("s3cret")},
+		{Name: types.StringValue("normal-info-1"), Value: types.StringValue("hello")},
+	})
+	knownTagSet := mustVariablesToSet([]Variable{
+		{Name: types.StringValue("scope"), Value: types.StringValue("org")},
+	})
+	unknownSet := types.SetUnknown(variableSetElemType)
+	nullSet := types.SetNull(variableSetElemType)
+
+	t.Run("BothUnknown", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, unknownSet, unknownSet)
+		require.True(t, result[0].TerraformVariables.IsUnknown())
+		require.True(t, result[0].ProvisionerTags.IsUnknown())
+		require.Equal(t, "stable-1", result[0].Name.ValueString())
+	})
+
+	t.Run("BothKnown", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, knownVarSet, knownTagSet)
+		require.False(t, result[0].TerraformVariables.IsUnknown())
+		require.False(t, result[0].ProvisionerTags.IsUnknown())
+		vars, d := variablesFromSet(ctx, result[0].TerraformVariables)
+		require.False(t, d.HasError())
+		require.Len(t, vars, 2)
+		tags, d := variablesFromSet(ctx, result[0].ProvisionerTags)
+		require.False(t, d.HasError())
+		require.Len(t, tags, 1)
+	})
+
+	t.Run("TFVarsUnknown_TagsKnown", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, unknownSet, knownTagSet)
+		require.True(t, result[0].TerraformVariables.IsUnknown())
+		require.False(t, result[0].ProvisionerTags.IsUnknown())
+	})
+
+	t.Run("TFVarsNull_TagsUnknown", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, nullSet, unknownSet)
+		require.True(t, result[0].TerraformVariables.IsNull())
+		require.True(t, result[0].ProvisionerTags.IsUnknown())
+	})
+
+	t.Run("BothNull", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, nullSet, nullSet)
+		require.True(t, result[0].TerraformVariables.IsNull())
+		require.True(t, result[0].ProvisionerTags.IsNull())
+	})
+
+	t.Run("BothEmpty", func(t *testing.T) {
+		t.Parallel()
+		result := buildAndDeserialize(t, emptyVariableSet(), emptyVariableSet())
+		require.False(t, result[0].TerraformVariables.IsNull())
+		require.False(t, result[0].TerraformVariables.IsUnknown())
+		vars, d := variablesFromSet(ctx, result[0].TerraformVariables)
+		require.False(t, d.HasError())
+		require.Empty(t, vars)
+	})
 }


### PR DESCRIPTION
## Problem

`coderd_template` fails during `ValidateResourceConfig` (and plan) with:

```
Value Conversion Error ... Received unknown value, however the target type
cannot handle unknown values. Path: [0].tf_vars,
Target Type: []provider.Variable, Suggested Type: basetypes.SetValue
```

whenever `tf_vars` or `provisioner_tags` are derived from module variables or sensitive values that Terraform marks as unknown at validate/plan time (for example `tf_vars = toset([for k, v in var.secrets : { name = k, value = v }])`).

The root cause is the data model: `TemplateVersion.TerraformVariables` and `TemplateVersion.ProvisionerTags` were plain Go slices (`[]Variable`). `ElementsAs` cannot decode an unknown set into a native slice, so both `versionsValidator.ValidateList` and `versionsPlanModifier.PlanModifyList` error out before the user ever reaches apply.

This was reported in #305 and is reproducible on `v0.0.16` and `v0.0.18`. #305 was auto-closed by #347, but #347 only fixed the plan-element rewriting path, not the `ValidateResourceConfig` path, so the bug is still present. **Please reopen #305** to track this.

## Fix

Change `TerraformVariables` and `ProvisionerTags` from `[]Variable` to `types.Set`, which can represent known, unknown, and null states. Native slices cannot represent Terraform's "unknown" sentinel, which is exactly the state these attributes take when their values flow from unknown variables.

Helpers (`variablesFromSet` / `variablesToSet` / `emptyVariableSet`) convert to and from `[]Variable` only when the set is known. Every consumer (`newVersion`, `setPrivateState`, `tfVariablesChanged`) unwraps the set defensively, treating null/unknown as "no known variables" (and, in `tfVariablesChanged`, treating an unknown set as changed so a new version is planned).

### Composition with #347

This change is complementary to #347, not an alternative:

- **#347** fixed plan-element rewriting in `PlanModifyList` (patch only `id`, `name`, and `directory_hash` on the original `attr.Value` elements instead of rebuilding the list with `ListValueFrom`, preserving cty sensitivity marks).
- **This PR** fixes the underlying data model so `ElementsAs` can decode unknown sets in the first place.

`PlanModifyList`'s element-patching logic is left untouched, so `tf_vars` / `provisioner_tags` keep their original `attr.Value`s (and their marks) on the plan.

## Credit

The original fix was authored by @jatcod3r and @PepziC0les in [jatcod3r/terraform-provider-coderd#1](https://github.com/jatcod3r/terraform-provider-coderd/pull/1) (branch `fix/unknown-tf-vars-provisioner-tags`), which was only ever opened against the fork's own `main`. This PR ports that work onto current upstream `main`, reconciles it with #347, and extends the regression coverage.

Fixes #305

<details>
<summary>Implementation notes and decision log</summary>

- The schema already declares `tf_vars` / `provisioner_tags` as `SetNestedAttribute`, which maps to `types.Set`. Only the Go struct field types were out of step with the schema; no schema change was needed.
- The fork commit (`afd101f`) predates #347 and its test hunk had broken brace indentation at the end of `TestReconcileVersionIDs`, so the change was hand-ported rather than cherry-picked. The post-#347 `PlanModifyList` was deliberately preserved.
- Consumers audited and updated: `newVersion`, `setPrivateState`, `reconcileVersionIDs` via `tfVariablesChanged`, and all `TestReconcileVersionIDs` fixtures. The acceptance-only `[]testAccTemplateKeyValueConfig` config struct is unrelated and was left as-is.

**Tests**

- `TestValidateListUnknownTFVars` (new): drives `versionsValidator.ValidateList` with an unknown `tf_vars`/`provisioner_tags` set element. This is the exact `ValidateResourceConfig` path from #305 and fails before this change.
- `TestUnknownTFVarsDeserialization` (new): exercises `ElementsAs` into `[]TemplateVersion` across known/unknown/null/empty combinations.
- `TestReconcileVersionIDs` (extended): adds `UnknownTFVarsHandled` and `NullTFVarsHandled` cases.
- `TestAccTemplateResourceSensitiveTFVarsDeferredReplan` (the #347 test) and `TestAccTemplateResourceVariables` were run locally with `TF_ACC=1` against `ghcr.io/coder/coder:latest` and pass, confirming #347 behavior is preserved.
- Reproducing "unknown at validate time" reliably in an acceptance test is impractical (the harness passes known variables), so the unit-level `ValidateList` test serves as the primary regression guard. Full `TF_ACC` runs are covered by CI.

Local checks run: `make fmt`, `make gen` (no doc changes), `golangci-lint run ./...` (v2.8.0, 0 issues), `go test ./internal/provider/ -short`.

</details>

---

cc @ethanndickson for review.

> Disclosure: this pull request was generated by Coder Agents on behalf of @ericpaulsen.
