### PR TITLE
test(internal/provider): cover tf_vars and provisioner_tags passed via input variables

### DIFF
--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -1194,7 +1194,9 @@ resource "coderd_template" "test" {
 // fields this failed with "Value Conversion Error ... Path: [0].tf_vars"
 // before the provider was even configured. The variables must not have
 // defaults; a default would make them known during the validate walk and skip
-// the regression entirely.
+// the regression entirely. The two variables deliberately use different type
+// constraints, list(object) and list(map(string)), to cover both input shapes
+// from the original reports.
 func TestAccTemplateResourceTFVarsFromVariable(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
@@ -1208,7 +1210,10 @@ provider coderd {
 }
 
 variable "template_variables" {
-	type = list(map(string))
+	type = list(object({
+		name = string,
+		value = any
+	}))
 }
 
 variable "provisioner_tags" {

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -1179,6 +1180,86 @@ resource "coderd_template" "test" {
 						"directory_hash": regexp.MustCompile(".+"),
 					}),
 					testAccCheckNumTemplateVersions(ctx, client, 2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccTemplateResourceTFVarsFromVariable reproduces issue #305: tf_vars and
+// provisioner_tags supplied through required input variables (the equivalent
+// of `terraform plan -var-file=...`) are unknown while Terraform's validate
+// walk runs at the start of plan and apply, because the validate walk
+// evaluates input variables without values as unknown. With []Variable struct
+// fields this failed with "Value Conversion Error ... Path: [0].tf_vars"
+// before the provider was even configured. The variables must not have
+// defaults; a default would make them known during the validate walk and skip
+// the regression entirely.
+func TestAccTemplateResourceTFVarsFromVariable(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests are disabled.")
+	}
+
+	cfg := `
+provider coderd {
+	url   = %q
+	token = %q
+}
+
+variable "template_variables" {
+	type = list(map(string))
+}
+
+variable "provisioner_tags" {
+	type = list(map(string))
+}
+
+resource "coderd_template" "test" {
+	name = "tf-vars-from-variable"
+
+	versions = [{
+		directory        = %q
+		active           = true
+		tf_vars          = var.template_variables
+		provisioner_tags = var.provisioner_tags
+	}]
+}
+`
+
+	ctx := t.Context()
+	client := integration.StartCoder(ctx, t, "template_tfvars_from_var_acc")
+
+	exTemplateOne := t.TempDir()
+	err := cp.Copy("../../integration/template-test/example-template", exTemplateOne)
+	require.NoError(t, err)
+
+	cfg = fmt.Sprintf(cfg, client.URL.String(), client.SessionToken(), exTemplateOne)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				ConfigVariables: config.Variables{
+					"template_variables": config.ListVariable(
+						config.MapVariable(map[string]config.Variable{
+							"name":  config.StringVariable("name"),
+							"value": config.StringVariable("world"),
+						}),
+					),
+					"provisioner_tags": config.ListVariable(),
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
+					resource.TestCheckResourceAttr("coderd_template.test", "versions.0.tf_vars.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("coderd_template.test", "versions.0.tf_vars.*", map[string]string{
+						"name":  "name",
+						"value": "world",
+					}),
+					testAccCheckNumTemplateVersions(ctx, client, 1),
 				),
 			},
 		},


### PR DESCRIPTION
Follow-up to #362, adding end-to-end regression coverage for #305 based on a customer-validated reproduction.

## Gap

`terraform plan` and `apply` run a validate walk first, in which **required input variables (no default) are evaluated as unknown**, even when a `-var-file` supplies concrete values. That walk calls `ValidateResourceConfig`, which is exactly where #305 blew up. No existing acceptance test could catch this class of bug: they all interpolate literal values into the config text, and the one variable-based test (`TestAccTemplateResourceSensitiveTFVarsDeferredReplan`) uses a variable with a `default`, which is known during the validate walk. The unit tests added in #362 cover the decode, but nothing exercised the real Terraform CLI path.

## Test

`TestAccTemplateResourceTFVarsFromVariable` mirrors the reported customer configuration: `tf_vars` and `provisioner_tags` supplied through required `list(map(string))` variables via `TestStep.ConfigVariables` (the harness equivalent of `terraform plan -var-file=...`), then a full plan, apply, and post-apply check. No license required.

Refs #305

<details>
<summary>Red/green validation and repro notes</summary>

- The customer config (`tf_vars = var.template_variables` with a required `list(map(string))` variable and `-var-file`) was reproduced verbatim against a provider built from `38cc6df` (pre-#362): `Value Conversion Error ... Path: [0].tf_vars, Target Type: []provider.Variable`, failing before the provider was even configured.
- The same config against merged `main` plans, applies against a local Coder v2.34.1 container, lands the variables on the created template version (verified via API), and re-plans empty.
- This test run against `38cc6df`: **fails** with `Value Conversion Error ... Path: [0].provisioner_tags, Target Type: []provider.Variable` (same decode; whichever field errors first).
- This test run against `main` with `TF_ACC=1`: **passes** in ~6.5s.
- The variables in the test intentionally have no defaults; adding a default would make them known during the validate walk and silently skip the regression.

</details>

> Disclosure: this pull request was generated by Coder Agents on behalf of @ericpaulsen.
