### PR TITLE
ci: use Depot runners for CI and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-8' || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
   # Ensure project builds before running testing matrix
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,7 +42,7 @@ jobs:
           install-mode: goinstall
 
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -66,7 +66,7 @@ jobs:
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -105,7 +105,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Switches the CI and release workflows over to Depot runners, mirroring the pattern used in [`coder/coder`](https://github.com/coder/coder). Each `runs-on` is guarded with `github.repository_owner == 'coder'` so forks continue to use `ubuntu-latest`.

### Sizing

Picked per-job based on the actual workload:

| Job | Runner | Why |
| --- | --- | --- |
| `build` (`test.yml`) | `depot-ubuntu-22.04-4` | `go build` + golangci-lint, 5 min cap |
| `generate` (`test.yml`) | `depot-ubuntu-22.04-4` | `go generate ./...` (tfplugindocs), light |
| `test` (`test.yml`) | `depot-ubuntu-22.04-4` | 10-way Terraform version matrix already parallelizes; per-shard work is container start + serial TF apply/destroy, not CPU-bound |
| `lint` (`test.yml`) | `depot-ubuntu-22.04-4` | `make fmt` + `make gen` diff check |
| `goreleaser` (`release.yml`) | `depot-ubuntu-22.04-8` | Cross-compiles ~15 OS/arch binaries + GPG-signs; Go cross-build parallelizes well |

The 4-core size for the acceptance-test matrix is deliberate: matrix fan-out already gives horizontal parallelism, and bumping each shard to 8 cores would roughly 2× Depot minutes for that workflow without meaningfully shortening wall-clock.
