### PR TITLE
chore: bump coder/coder SDK and adapt to chat model config changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	cdr.dev/slog/v3 v3.1.0
-	github.com/coder/coder/v2 v2.34.0-rc.0.0.20260624160327-8bf6f4301614
+	github.com/coder/coder/v2 v2.34.0-rc.0.0.20260701204415-db7f4438b4ad
 	github.com/coder/retry v1.5.1
 	github.com/coder/serpent v0.15.0
 	github.com/coder/websocket v1.8.15
@@ -180,7 +180,7 @@ require (
 	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
-	github.com/valyala/fasthttp v1.71.0 // indirect
+	github.com/valyala/fasthttp v1.72.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
@@ -219,7 +219,7 @@ require (
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	golang.org/x/tools v0.46.0 // indirect
+	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260610212136-7ab31c22f7ad // indirect
@@ -227,7 +227,7 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.0 // indirect
-	gopkg.in/ini.v1 v1.67.2 // indirect
+	gopkg.in/ini.v1 v1.67.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	storj.io/drpc v0.0.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/clipperhouse/uax29/v2 v2.6.0 h1:z0cDbUV+aPASdFb2/ndFnS9ts/WNXgTNNGFoK
 github.com/clipperhouse/uax29/v2 v2.6.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/coder/coder/v2 v2.34.0-rc.0.0.20260624160327-8bf6f4301614 h1:T0U4vKQxdVZQqBpYAnsi3FOA+UXQmEzSXikWD2AupG0=
-github.com/coder/coder/v2 v2.34.0-rc.0.0.20260624160327-8bf6f4301614/go.mod h1:sgtSdROCAkeBdYj1BK6wqs1Ls9xoFv4ksoTgnD4EyDc=
+github.com/coder/coder/v2 v2.34.0-rc.0.0.20260701204415-db7f4438b4ad h1:dVCql8eMM+GBtPmIvdY1hPvONY234fmeZjNLYp5+IVQ=
+github.com/coder/coder/v2 v2.34.0-rc.0.0.20260701204415-db7f4438b4ad/go.mod h1:sJc0Y7Rd2kzqjdCMwfrebST+qPJprLub3+TVS7jXHQo=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0 h1:3A0ES21Ke+FxEM8CXx9n47SZOKOpgSE1bbJzlE4qPVs=
 github.com/coder/pretty v0.0.0-20230908205945-e89ba86370e0/go.mod h1:5UuS2Ts+nTToAMeOjNlnHFkPahrtDkmpydBen/3wgZc=
 github.com/coder/retry v1.5.1 h1:iWu8YnD8YqHs3XwqrqsjoBTAVqT9ml6z9ViJ2wlMiqc=
@@ -498,8 +498,8 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.71.0 h1:tepR7H+Guh9VUqxxcPggYi8R3lGUu2Rsdh+z7/FCY3k=
-github.com/valyala/fasthttp v1.71.0/go.mod h1:z1sDUvOShhXq/C9mwH/fSm1Vb71tUJwmQdgkBrBNwnA=
+github.com/valyala/fasthttp v1.72.0 h1:R7kYdoWhn1ye1fVpP+cDHDJwYm3NkwLliwgzJ/Abg7M=
+github.com/valyala/fasthttp v1.72.0/go.mod h1:zsbLTYqcpIktdQytlVBwIjY9La5d6bs990nBxWg8efk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -706,8 +706,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.46.0 h1:7jTurBkPZu4moS/Uy4OQT1M+QBlsj3wejyZwsT8Z7rk=
-golang.org/x/tools v0.46.0/go.mod h1:FrD85F8l+NWL+9XWBSyVSHO6Ne4jutsfIFba7AWQ5Ys=
+golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -738,8 +738,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/ini.v1 v1.67.2 h1:JtOSMb9OuaCZKr7h5D/h6iii14sK0hLbplTc6frx4Ss=
-gopkg.in/ini.v1 v1.67.2/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/ini.v1 v1.67.3 h1:iM9Lhz5MRSGhHVGGwCuzG9KO8PoirCXj/m/qTmOJJQw=
+gopkg.in/ini.v1 v1.67.3/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coder/coder/v2/codersdk"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -208,6 +209,11 @@ func TestIntegration(t *testing.T) {
 				configs, err := exp.ListChatModelConfigs(ctx)
 				require.NoError(t, err)
 
+				providerTypeByID := make(map[uuid.UUID]string, len(providers))
+				for _, p := range providers {
+					providerTypeByID[p.ID] = string(p.Type)
+				}
+
 				// model -> {provider type, expected model_config JSON} (mirrors main.tf).
 				want := map[string]struct{ provider, config string }{
 					"claude-opus-4-8": {"anthropic", `{
@@ -275,7 +281,7 @@ func TestIntegration(t *testing.T) {
 					}
 					w, ok := want[m.Model]
 					require.True(t, ok, "unexpected model %s", m.Model)
-					assert.Equal(t, w.provider, m.Provider)
+					assert.Equal(t, w.provider, providerTypeByID[m.AIProviderID])
 					require.NotNil(t, m.ModelConfig)
 					got, err := json.Marshal(m.ModelConfig)
 					require.NoError(t, err)

--- a/internal/provider/agents_model_resource.go
+++ b/internal/provider/agents_model_resource.go
@@ -205,11 +205,24 @@ func (r *AgentsModelResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	state := stateFromModelConfig(modelConfig, &resp.Diagnostics)
+	providerType := r.lookupProviderType(ctx, modelConfig, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state := stateFromModelConfig(modelConfig, providerType, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *AgentsModelResource) lookupProviderType(ctx context.Context, config codersdk.ChatModelConfig, diags *diag.Diagnostics) string {
+	provider, err := r.data.Client.AIProvider(ctx, config.AIProviderID.String())
+	if err != nil {
+		diags.AddError("Client Error", fmt.Sprintf("Unable to read AI provider %s to derive provider_type, got error: %s", config.AIProviderID, err))
+		return ""
+	}
+	return string(provider.Type)
 }
 
 // createChatModelConfigWithRetry retries CreateChatModelConfig on the 409
@@ -254,7 +267,11 @@ func (r *AgentsModelResource) Read(ctx context.Context, req resource.ReadRequest
 
 	for _, config := range configs {
 		if config.ID == modelConfigID {
-			refreshed := stateFromModelConfig(config, &resp.Diagnostics)
+			providerType := r.lookupProviderType(ctx, config, &resp.Diagnostics)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			refreshed := stateFromModelConfig(config, providerType, &resp.Diagnostics)
 			if resp.Diagnostics.HasError() {
 				return
 			}
@@ -286,7 +303,11 @@ func (r *AgentsModelResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updated := stateFromModelConfig(modelConfig, &resp.Diagnostics)
+	providerType := r.lookupProviderType(ctx, modelConfig, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	updated := stateFromModelConfig(modelConfig, providerType, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -357,10 +378,11 @@ func (m AgentsModelResourceModel) updateRequest(state AgentsModelResourceModel, 
 	return req
 }
 
-func stateFromModelConfig(config codersdk.ChatModelConfig, diags *diag.Diagnostics) AgentsModelResourceModel {
-	out := AgentsModelResourceModel{
+func stateFromModelConfig(config codersdk.ChatModelConfig, providerType string, diags *diag.Diagnostics) AgentsModelResourceModel {
+	return AgentsModelResourceModel{
 		ID:                   UUIDValue(config.ID),
-		ProviderType:         types.StringValue(config.Provider),
+		AIProviderID:         UUIDValue(config.AIProviderID),
+		ProviderType:         types.StringValue(providerType),
 		Model:                types.StringValue(config.Model),
 		DisplayName:          types.StringValue(config.DisplayName),
 		Enabled:              types.BoolValue(config.Enabled),
@@ -370,12 +392,6 @@ func stateFromModelConfig(config codersdk.ChatModelConfig, diags *diag.Diagnosti
 		CreatedAt:            types.Int64Value(config.CreatedAt.Unix()),
 		UpdatedAt:            types.Int64Value(config.UpdatedAt.Unix()),
 	}
-	if config.AIProviderID != nil {
-		out.AIProviderID = UUIDValue(*config.AIProviderID)
-	} else {
-		out.AIProviderID = NewUUIDNull()
-	}
-	return out
 }
 
 // agentsModelDecodeConfig decodes the model_config JSON string into the SDK

--- a/internal/provider/agents_model_resource_test.go
+++ b/internal/provider/agents_model_resource_test.go
@@ -46,7 +46,6 @@ func TestAgentsModelCreateRequest(t *testing.T) {
 	var diags diag.Diagnostics
 	req := plan.createRequest(&diags)
 	require.False(t, diags.HasError(), diags.Errors())
-	require.Empty(t, req.Provider, "provider is derived server-side")
 	require.NotNil(t, req.AIProviderID)
 	require.Equal(t, aiProviderID, *req.AIProviderID)
 	require.Equal(t, "claude-3-5-sonnet-20241022", req.Model)
@@ -133,8 +132,7 @@ func TestAgentsModelStateFromModelConfig(t *testing.T) {
 	var diags diag.Diagnostics
 	state := stateFromModelConfig(codersdk.ChatModelConfig{
 		ID:                   modelConfigID,
-		Provider:             "anthropic",
-		AIProviderID:         &aiProviderID,
+		AIProviderID:         aiProviderID,
 		Model:                "claude-3-5-sonnet-20241022",
 		DisplayName:          "Claude 3.5 Sonnet",
 		Enabled:              true,
@@ -143,7 +141,7 @@ func TestAgentsModelStateFromModelConfig(t *testing.T) {
 		ModelConfig:          remote,
 		CreatedAt:            createdAt,
 		UpdatedAt:            updatedAt,
-	}, &diags)
+	}, "anthropic", &diags)
 	require.False(t, diags.HasError(), diags.Errors())
 	require.Equal(t, modelConfigID, state.ID.ValueUUID())
 	require.Equal(t, aiProviderID, state.AIProviderID.ValueUUID())


### PR DESCRIPTION
Bumps `github.com/coder/coder/v2` so the next PR in this stack can use the Bedrock external ID from coder/coder#26869.

The bump also pulls in coder/coder#26877, which removed the `provider` field from chat model configs and made `ai_provider_id` required. The `coderd_agents_model` resource keeps its `provider_type` attribute, but now derives it by looking up the linked AI provider, which is upstream's stated migration path.

This stays compatible with older Coder servers: the provider never sent a `provider` field in requests, and the lookup used to derive `provider_type` hits the AI provider endpoint that predates this change. The response decode is also version-agnostic — the removed `provider` column is simply an unknown field that Go drops, and `ai_provider_id` decodes into the non-pointer `uuid.UUID` identically on both old and new servers.

Refs coder/coder#26877.

Closes CODAGT-753
