### PR TITLE
feat(coderd_template): make versions optional

### DIFF
--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -61,7 +61,6 @@ resource "coderd_template" "ubuntu-main" {
 ### Required
 
 - `name` (String) The name of the template.
-- `versions` (Attributes List) (see [below for nested schema](#nestedatt--versions))
 
 ### Optional
 
@@ -85,10 +84,47 @@ resource "coderd_template" "ubuntu-main" {
 - `time_til_dormant_autodelete_ms` (Number) (Enterprise) The max lifetime before Coder permanently deletes dormant workspaces created from this template.
 - `time_til_dormant_ms` (Number) (Enterprise) The max lifetime before Coder locks inactive workspaces created from this template, in milliseconds.
 - `use_classic_parameter_flow` (Boolean) If true, the classic parameter flow will be used when creating workspaces from this template. Defaults to false.
+- `versions` (Attributes List) The template versions to manage. If null, Terraform will not create, update, or read template versions, and will only manage the template's other settings. At least one version (with `active = true`) is required when creating a new template, since Coder templates cannot exist without a version. (see [below for nested schema](#nestedatt--versions))
 
 ### Read-Only
 
 - `id` (String) The ID of the template.
+
+<a id="nestedatt--acl"></a>
+### Nested Schema for `acl`
+
+Required:
+
+- `groups` (Attributes Set) (see [below for nested schema](#nestedatt--acl--groups))
+- `users` (Attributes Set) (see [below for nested schema](#nestedatt--acl--users))
+
+<a id="nestedatt--acl--groups"></a>
+### Nested Schema for `acl.groups`
+
+Required:
+
+- `id` (String)
+- `role` (String)
+
+
+<a id="nestedatt--acl--users"></a>
+### Nested Schema for `acl.users`
+
+Required:
+
+- `id` (String)
+- `role` (String)
+
+
+
+<a id="nestedatt--auto_stop_requirement"></a>
+### Nested Schema for `auto_stop_requirement`
+
+Optional:
+
+- `days_of_week` (Set of String) List of days of the week on which restarts are required. Restarts happen within the user's quiet hours (in their configured timezone). If no days are specified, restarts are not required.
+- `weeks` (Number) Weeks is the number of weeks between required restarts. Weeks are synced across all workspaces (and Coder deployments) using modulo math on a hardcoded epoch week of January 2nd, 2023 (the first Monday of 2023). Values of 0 or 1 indicate weekly restarts. Values of 2 indicate fortnightly restarts, etc.
+
 
 <a id="nestedatt--versions"></a>
 ### Nested Schema for `versions`
@@ -127,43 +163,6 @@ Required:
 - `name` (String)
 - `value` (String)
 
-
-
-<a id="nestedatt--acl"></a>
-### Nested Schema for `acl`
-
-Required:
-
-- `groups` (Attributes Set) (see [below for nested schema](#nestedatt--acl--groups))
-- `users` (Attributes Set) (see [below for nested schema](#nestedatt--acl--users))
-
-<a id="nestedatt--acl--groups"></a>
-### Nested Schema for `acl.groups`
-
-Required:
-
-- `id` (String)
-- `role` (String)
-
-
-<a id="nestedatt--acl--users"></a>
-### Nested Schema for `acl.users`
-
-Required:
-
-- `id` (String)
-- `role` (String)
-
-
-
-<a id="nestedatt--auto_stop_requirement"></a>
-### Nested Schema for `auto_stop_requirement`
-
-Optional:
-
-- `days_of_week` (Set of String) List of days of the week on which restarts are required. Restarts happen within the user's quiet hours (in their configured timezone). If no days are specified, restarts are not required.
-- `weeks` (Number) Weeks is the number of weeks between required restarts. Weeks are synced across all workspaces (and Coder deployments) using modulo math on a hardcoded epoch week of January 2nd, 2023 (the first Monday of 2023). Values of 0 or 1 indicate weekly restarts. Values of 2 indicate fortnightly restarts, etc.
-
 ## Import
 
 Import is supported using the following syntax:
@@ -176,8 +175,12 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 $ terraform import coderd_template.example coder/dogfood
 ```
 Once imported, you'll need to manually declare in your config:
-- The `versions` list, in order to specify the source directories for new versions of the template.
 - (Enterprise) The `acl` attribute, in order to specify the users and groups that have access to the template.
+- The `versions` list, if you want Terraform to manage the template's versions. If
+  you omit `versions` (or leave it `null`), Terraform will only manage the
+  template's other settings (ACL, dormancy, TTLs, etc.) and will not create,
+  update, or read any template versions — this is useful when versions are pushed
+  by an external pipeline (e.g. via `coder templates push`).
 
 Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
 

--- a/examples/resources/coderd_template/import.sh
+++ b/examples/resources/coderd_template/import.sh
@@ -3,8 +3,12 @@
 $ terraform import coderd_template.example coder/dogfood
 ```
 Once imported, you'll need to manually declare in your config:
-- The `versions` list, in order to specify the source directories for new versions of the template.
 - (Enterprise) The `acl` attribute, in order to specify the users and groups that have access to the template.
+- The `versions` list, if you want Terraform to manage the template's versions. If
+  you omit `versions` (or leave it `null`), Terraform will only manage the
+  template's other settings (ACL, dormancy, TTLs, etc.) and will not create,
+  update, or read any template versions — this is useful when versions are pushed
+  by an external pipeline (e.g. via `coder templates push`).
 
 Alternatively, in Terraform v1.5.0 and later, an [`import` block](https://developer.hashicorp.com/terraform/language/import) can be used:
 

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -555,16 +555,9 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	if len(data.Versions) == 0 {
-		resp.Diagnostics.AddError("Client Error",
-			"At least one template version (with `active = true`) is required when "+
-				"creating a new `coderd_template` resource, since Coder templates cannot "+
-				"exist without a version.\nTo manage an existing template without "+
-				"Terraform-managed versions, use `terraform import` instead.")
-		return
-	}
-	// The active-version requirement is enforced at plan-time by
-	// versionsPlanModifier.PlanModifyList, so it doesn't need to be repeated here.
+	// The "at least one version is required when creating" requirement is
+	// enforced at plan-time by versionsPlanModifier.PlanModifyList, so it
+	// doesn't need to be repeated here.
 
 	if data.OrganizationID.IsUnknown() {
 		data.OrganizationID = UUIDValue(r.data.DefaultOrganizationID)
@@ -1047,6 +1040,13 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 	// Returning here (without touching resp.PlanValue) leaves the planned
 	// value as-is, preserving null instead of coercing it into an empty list.
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		if req.ConfigValue.IsNull() && req.State.Raw.IsNull() {
+			resp.Diagnostics.AddError("Client Error",
+				"At least one template version (with `active = true`) is required when "+
+					"creating a new `coderd_template` resource, since Coder templates cannot "+
+					"exist without a version.\nTo manage an existing template without "+
+					"Terraform-managed versions, use `terraform import` instead.")
+		}
 		return
 	}
 

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/retry"
 	"github.com/coder/terraform-provider-coderd/internal/codersdkvalidator"
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -469,6 +470,7 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				MarkdownDescription: "The template versions to manage. If null, Terraform will not create, update, or read template versions, and will only manage the template's other settings. At least one version (with `active = true`) is required when creating a new template, since Coder templates cannot exist without a version.",
 				Optional:            true,
 				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
 					NewVersionsValidator(),
 				},
 				NestedObject: schema.NestedAttributeObject{
@@ -561,16 +563,8 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 				"Terraform-managed versions, use `terraform import` instead.")
 		return
 	}
-	if hasActiveVersion, diag := hasOneActiveVersion(data.Versions); diag.HasError() {
-		resp.Diagnostics.Append(diag...)
-		return
-	} else if !hasActiveVersion {
-		resp.Diagnostics.AddError("Client Error",
-			"At least one template version must be active when creating a "+
-				"`coderd_template` resource.\n(Subsequent resource updates can be made "+
-				"without an active template in the list).")
-		return
-	}
+	// The active-version requirement is enforced at plan-time by
+	// versionsPlanModifier.PlanModifyList, so it doesn't need to be repeated here.
 
 	if data.OrganizationID.IsUnknown() {
 		data.OrganizationID = UUIDValue(r.data.DefaultOrganizationID)
@@ -1073,6 +1067,16 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		return
 	}
 
+	// req.State.Raw.IsNull() is true only when there's no prior state at all,
+	// i.e. this is a genuine Create (unlike checking private state for nil,
+	// this stays false for a resource that was `terraform import`ed with
+	// `versions` omitted, since import populates state before this runs).
+	if req.State.Raw.IsNull() && !hasActiveVersion {
+		resp.Diagnostics.AddError("Client Error", "At least one template version must be active when creating a"+
+			" `coderd_template` resource.\n(Subsequent resource updates can be made without an active template in the list).")
+		return
+	}
+
 	for i := range planVersions {
 		hash, err := computeDirectoryHash(planVersions[i].Directory.ValueString())
 		if err != nil {
@@ -1089,11 +1093,6 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		return
 	}
 	// If this is the first read, init the private state value.
-	// Note: this is also true for a resource that was `terraform import`ed
-	// with `versions` omitted from config (Create never ran for it), so we
-	// can't use "no prior private state" as a proxy for "this is being
-	// created" here — that check now lives in Create() itself, where it's
-	// unambiguous.
 	if lvBytes == nil {
 		lv = make(LastVersionsByHash)
 	} else {

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/coder/retry"
 	"github.com/coder/terraform-provider-coderd/internal/codersdkvalidator"
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -467,9 +466,9 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				},
 			},
 			"versions": schema.ListNestedAttribute{
-				Required: true,
+				MarkdownDescription: "The template versions to manage. If null, Terraform will not create, update, or read template versions, and will only manage the template's other settings. At least one version (with `active = true`) is required when creating a new template, since Coder templates cannot exist without a version.",
+				Optional:            true,
 				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
 					NewVersionsValidator(),
 				},
 				NestedObject: schema.NestedAttributeObject{
@@ -551,6 +550,25 @@ func (r *TemplateResource) Create(ctx context.Context, req resource.CreateReques
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(data.Versions) == 0 {
+		resp.Diagnostics.AddError("Client Error",
+			"At least one template version (with `active = true`) is required when "+
+				"creating a new `coderd_template` resource, since Coder templates cannot "+
+				"exist without a version.\nTo manage an existing template without "+
+				"Terraform-managed versions, use `terraform import` instead.")
+		return
+	}
+	if hasActiveVersion, diag := hasOneActiveVersion(data.Versions); diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		return
+	} else if !hasActiveVersion {
+		resp.Diagnostics.AddError("Client Error",
+			"At least one template version must be active when creating a "+
+				"`coderd_template` resource.\n(Subsequent resource updates can be made "+
+				"without an active template in the list).")
 		return
 	}
 
@@ -1030,6 +1048,14 @@ func (d *versionsPlanModifier) MarkdownDescription(context.Context) string {
 
 // PlanModifyObject implements planmodifier.List.
 func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// `versions` is optional: if it's null or unknown, Terraform is not
+	// managing template versions at all, so there's nothing to reconcile.
+	// Returning here (without touching resp.PlanValue) leaves the planned
+	// value as-is, preserving null instead of coercing it into an empty list.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
 	var planVersions Versions
 	resp.Diagnostics.Append(req.PlanValue.ElementsAs(ctx, &planVersions, false)...)
 	if resp.Diagnostics.HasError() {
@@ -1062,16 +1088,14 @@ func (d *versionsPlanModifier) PlanModifyList(ctx context.Context, req planmodif
 		resp.Diagnostics.Append(diag...)
 		return
 	}
-	// If this is the first read, init the private state value
+	// If this is the first read, init the private state value.
+	// Note: this is also true for a resource that was `terraform import`ed
+	// with `versions` omitted from config (Create never ran for it), so we
+	// can't use "no prior private state" as a proxy for "this is being
+	// created" here — that check now lives in Create() itself, where it's
+	// unambiguous.
 	if lvBytes == nil {
 		lv = make(LastVersionsByHash)
-		// If there's no prior private state, this might be resource creation,
-		// in which case one version must be active.
-		if !hasActiveVersion {
-			resp.Diagnostics.AddError("Client Error", "At least one template version must be active when creating a"+
-				" `coderd_template` resource.\n(Subsequent resource updates can be made without an active template in the list).")
-			return
-		}
 	} else {
 		err := json.Unmarshal(lvBytes, &lv)
 		if err != nil {

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -679,6 +679,172 @@ func TestAccTemplateResource(t *testing.T) {
 	})
 }
 
+// TestAccTemplateResourceOptionalVersions covers PLAT-288: `versions` is
+// optional, so `coderd_template` can manage a template's settings without
+// owning its version lifecycle. A template still can't be *created* without
+// at least one version (Coderd has no concept of a versionless template), so
+// that case is expected to keep failing with a clear error.
+func TestAccTemplateResourceOptionalVersions(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests are disabled.")
+	}
+	ctx := t.Context()
+	client := integration.StartCoder(ctx, t, "template_optional_versions_acc")
+
+	exTemplate := t.TempDir()
+	err := cp.Copy("../../integration/template-test/example-template", exTemplate)
+	require.NoError(t, err)
+
+	t.Run("CreateWithoutVersionsErrors", func(t *testing.T) {
+		cfg := testAccTemplateResourceConfig{
+			URL:          client.URL.String(),
+			Token:        client.SessionToken(),
+			Name:         ptr.Ref("no-versions-template"),
+			VersionsNull: true,
+			ACL:          testAccTemplateACLConfig{null: true},
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: cfg.String(t),
+					// Terraform's CLI diagnostic renderer word-wraps long error
+					// text with real newlines, so `.` must match them too.
+					ExpectError: regexp.MustCompile("(?s)At least one template version.*is required when.*creating"),
+				},
+			},
+		})
+	})
+
+	t.Run("SettingsOnlyManagementAfterDroppingVersions", func(t *testing.T) {
+		firstUser, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		orgID := firstUser.OrganizationIDs[0]
+
+		cfgManaged := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  ptr.Ref("settings-only-template"),
+			Versions: []testAccTemplateVersionConfig{
+				{
+					Directory: &exTemplate,
+					Active:    ptr.Ref(true),
+				},
+			},
+			ACL: testAccTemplateACLConfig{null: true},
+		}
+
+		cfgUnmanaged := cfgManaged
+		cfgUnmanaged.Versions = nil
+		cfgUnmanaged.VersionsNull = true
+
+		cfgUnmanagedWithNewDescription := cfgUnmanaged
+		cfgUnmanagedWithNewDescription.Description = ptr.Ref("now managed by an external pipeline")
+
+		// Captured from state in the first step's Check, then used both to
+		// simulate the pipeline's out-of-band push (PreConfig runs before a
+		// step's plan/apply and has no access to *terraform.State, so the ID
+		// has to be threaded through this way) and to verify against the
+		// Coderd API directly in the last step.
+		var templateID uuid.UUID
+		var pipelineVersionID uuid.UUID
+		captureTemplateID := func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources["coderd_template.test"]
+			if !ok {
+				return fmt.Errorf("coderd_template.test not found in state")
+			}
+			id, err := uuid.Parse(rs.Primary.ID)
+			if err != nil {
+				return fmt.Errorf("failed to parse template id %q: %w", rs.Primary.ID, err)
+			}
+			templateID = id
+			return nil
+		}
+
+		// Simulates the customer's own CI pipeline calling `coder templates
+		// push --activate` outside of Terraform, after Terraform has stopped
+		// tracking any version for this template.
+		pushAndActivateExternalVersion := func() {
+			version := TemplateVersion{
+				Directory:          types.StringValue(exTemplate),
+				TerraformVariables: emptyVariableSet(),
+				ProvisionerTags:    emptyVariableSet(),
+			}
+			versionResp, logs, err := newVersion(ctx, client, newVersionRequest{
+				Version:        &version,
+				OrganizationID: orgID,
+				TemplateID:     &templateID,
+			})
+			require.NoError(t, err, "%v", logs)
+			require.NoError(t, markActive(ctx, client, templateID, versionResp.ID))
+			pipelineVersionID = versionResp.ID
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Terraform creates the template and its first version, as usual.
+				{
+					Config: cfgManaged.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet("coderd_template.test", "id"),
+						resource.TestCheckResourceAttr("coderd_template.test", "versions.#", "1"),
+						testAccCheckNumTemplateVersions(ctx, client, 1),
+						captureTemplateID,
+					),
+				},
+				// The team switches to a custom pipeline for pushing versions;
+				// Terraform is told to stop tracking versions entirely.
+				{
+					Config: cfgUnmanaged.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr("coderd_template.test", "versions"),
+						testAccCheckNumTemplateVersions(ctx, client, 1),
+					),
+				},
+				// The pipeline pushes and activates a new version, entirely
+				// outside Terraform. Terraform's config is unchanged, so the
+				// next plan/apply should be a no-op: it isn't tracking any
+				// version, so there's nothing to reconcile or fight over.
+				{
+					PreConfig: pushAndActivateExternalVersion,
+					Config:    cfgUnmanaged.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr("coderd_template.test", "versions"),
+						testAccCheckNumTemplateVersions(ctx, client, 2),
+					),
+				},
+				// Terraform updates a setting. Only the setting should change:
+				// the pipeline's active version must survive untouched.
+				{
+					Config: cfgUnmanagedWithNewDescription.String(t),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("coderd_template.test", "description", "now managed by an external pipeline"),
+						resource.TestCheckNoResourceAttr("coderd_template.test", "versions"),
+						testAccCheckNumTemplateVersions(ctx, client, 2),
+						func(*terraform.State) error {
+							tmpl, err := client.Template(ctx, templateID)
+							if err != nil {
+								return err
+							}
+							if tmpl.ActiveVersionID != pipelineVersionID {
+								return fmt.Errorf("expected pipeline-pushed version %s to remain active, got %s", pipelineVersionID, tmpl.ActiveVersionID)
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+}
+
 func TestAccTemplateResourceEnterprise(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
@@ -1295,8 +1461,12 @@ type testAccTemplateResourceConfig struct {
 	CORSBehavior                 *string
 	UseClassicParameterFlow      *bool
 
-	Versions []testAccTemplateVersionConfig
-	ACL      testAccTemplateACLConfig
+	// VersionsNull renders `versions = null` instead of a list, regardless of
+	// the contents of Versions. Used to test that Terraform can manage a
+	// template's settings without owning its version lifecycle.
+	VersionsNull bool
+	Versions     []testAccTemplateVersionConfig
+	ACL          testAccTemplateACLConfig
 }
 
 type testAccTemplateACLConfig struct {
@@ -1374,6 +1544,48 @@ func (c testAccAutostopRequirementConfig) String(t *testing.T) string {
 	return buf.String()
 }
 
+// versionsString renders the `versions` attribute. When VersionsNull is set,
+// it renders `null` regardless of the contents of Versions, so tests can
+// exercise settings-only management of a template (see PLAT-288).
+func (c testAccTemplateResourceConfig) versionsString(t *testing.T) string {
+	t.Helper()
+	if c.VersionsNull {
+		return "null"
+	}
+	tpl := `[
+	{{- range . }}
+	{
+		name      = {{orNull .Name}}
+		directory = {{orNull .Directory}}
+		active    = {{orNull .Active}}
+
+		tf_vars = [
+			{{- range .TerraformVariables }}
+			{
+				name  = {{orNull .Key}}
+				value = {{orNull .Value}}
+			},
+			{{- end}}
+		]
+	},
+	{{- end}}
+	]
+	`
+
+	funcMap := template.FuncMap{
+		"orNull": PrintOrNull,
+	}
+
+	buf := strings.Builder{}
+	tmpl, err := template.New("versions").Funcs(funcMap).Parse(tpl)
+	require.NoError(t, err)
+
+	err = tmpl.Execute(&buf, c.Versions)
+	require.NoError(t, err)
+
+	return buf.String()
+}
+
 func (c testAccTemplateResourceConfig) String(t *testing.T) string {
 	t.Helper()
 	tpl := `
@@ -1406,24 +1618,7 @@ resource "coderd_template" "test" {
 
 	acl = ` + c.ACL.String(t) + `
 
-	versions = [
-	{{- range .Versions }}
-	{
-		name      = {{orNull .Name}}
-		directory = {{orNull .Directory}}
-		active    = {{orNull .Active}}
-
-		tf_vars = [
-			{{- range .TerraformVariables }}
-			{
-				name  = {{orNull .Key}}
-				value = {{orNull .Value}}
-			},
-			{{- end}}
-		]
-	},
-	{{- end}}
-	]
+	versions = ` + c.versionsString(t) + `
 }
 `
 

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -457,7 +457,11 @@ func TestAccTemplateResource(t *testing.T) {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config:      cfg1.String(t),
+					Config: cfg1.String(t),
+					// PlanOnly asserts this is caught by the versions plan
+					// modifier during `terraform plan`, not deferred to
+					// `terraform apply`
+					PlanOnly:    true,
 					ExpectError: regexp.MustCompile("At least one template version must be active when creating"),
 				},
 			},
@@ -715,6 +719,82 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 					// Terraform's CLI diagnostic renderer word-wraps long error
 					// text with real newlines, so `.` must match them too.
 					ExpectError: regexp.MustCompile("(?s)At least one template version.*is required when.*creating"),
+				},
+			},
+		})
+	})
+
+	t.Run("ImportThenPlanWithoutActiveVersionDoesNotError", func(t *testing.T) {
+		firstUser, err := client.User(ctx, codersdk.Me)
+		require.NoError(t, err)
+		orgID := firstUser.OrganizationIDs[0]
+
+		// Create the template directly via the API rather than through
+		// Terraform: a resource.Test call destroys everything it created
+		// once it returns, which would delete the template before the
+		// import step below ever got to see it.
+		version, _, err := newVersion(ctx, client, newVersionRequest{
+			OrganizationID: orgID,
+			Version: &TemplateVersion{
+				Directory:          types.StringValue(exTemplate),
+				TerraformVariables: emptyVariableSet(),
+				ProvisionerTags:    emptyVariableSet(),
+			},
+		})
+		require.NoError(t, err)
+		tpl, err := client.CreateTemplate(ctx, orgID, codersdk.CreateTemplateRequest{
+			Name:      "import-no-active-template",
+			VersionID: version.ID,
+		})
+		require.NoError(t, err)
+
+		cfgManaged := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  ptr.Ref(tpl.Name),
+			Versions: []testAccTemplateVersionConfig{
+				{
+					Directory: &exTemplate,
+					Active:    ptr.Ref(true),
+				},
+			},
+			ACL: testAccTemplateACLConfig{null: true},
+		}
+
+		// Describes the same template post-import, without marking any
+		// version active. The template already has an active version on
+		// the server; this config is just adopting it, not creating it.
+		cfgReimported := cfgManaged
+		cfgReimported.Versions = slices.Clone(cfgReimported.Versions)
+		cfgReimported.Versions[0].Active = ptr.Ref(false)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Import into brand new state. `Create` never runs for this
+				// resource instance, so there's no private-state record of
+				// any tracked version -- exactly the scenario that broke the
+				// old private-state-is-nil creation heuristic.
+				{
+					Config:             cfgManaged.String(t),
+					ResourceName:       "coderd_template.test",
+					ImportState:        true,
+					ImportStateId:      tpl.ID.String(),
+					ImportStatePersist: true,
+				},
+				// The first plan after import must not demand an active
+				// version just because there's no tracked private state:
+				// req.State.Raw.IsNull() (unlike the old private-state-is-nil
+				// heuristic it replaced) correctly recognizes this isn't a
+				// Create, since prior state already exists from the import.
+				// A non-empty plan is expected, since Terraform is now
+				// tracking this version for the first time.
+				{
+					Config:             cfgReimported.String(t),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
 				},
 			},
 		})

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -714,7 +714,8 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
 				{
-					Config: cfg.String(t),
+					Config:   cfg.String(t),
+					PlanOnly: true,
 					// Terraform's CLI diagnostic renderer word-wraps long error
 					// text with real newlines, so `.` must match them too.
 					ExpectError: regexp.MustCompile("(?s)At least one template version.*is required when.*creating"),

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -58,27 +58,27 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
 		cfg2.Name = ptr.Ref("example-template-new")
-		cfg2.Versions[0].Directory = &exTemplateTwo
-		cfg2.Versions[0].Name = ptr.Ref("new")
+		(*cfg2.Versions)[0].Directory = &exTemplateTwo
+		(*cfg2.Versions)[0].Name = ptr.Ref("new")
 
 		cfg3 := cfg2
-		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions = append(cfg3.Versions, testAccTemplateVersionConfig{
+		cfg3.Versions = ptr.Ref(slices.Clone(*cfg3.Versions))
+		cfg3.Versions = ptr.Ref(append(*cfg3.Versions, testAccTemplateVersionConfig{
 			Name:      ptr.Ref("legacy-template"),
 			Directory: &exTemplateOne,
 			Active:    ptr.Ref(false),
@@ -88,19 +88,19 @@ func TestAccTemplateResource(t *testing.T) {
 					Value: ptr.Ref("world"),
 				},
 			},
-		})
+		}))
 
 		cfg4 := cfg3
-		cfg4.Versions = slices.Clone(cfg4.Versions)
-		cfg4.Versions[0].Active = ptr.Ref(false)
-		cfg4.Versions[1].Active = ptr.Ref(true)
+		cfg4.Versions = ptr.Ref(slices.Clone(*cfg4.Versions))
+		(*cfg4.Versions)[0].Active = ptr.Ref(false)
+		(*cfg4.Versions)[1].Active = ptr.Ref(true)
 
 		cfg5 := cfg4
-		cfg5.Versions = slices.Clone(cfg5.Versions)
-		cfg5.Versions[0], cfg5.Versions[1] = cfg5.Versions[1], cfg5.Versions[0]
+		cfg5.Versions = ptr.Ref(slices.Clone(*cfg5.Versions))
+		(*cfg5.Versions)[0], (*cfg5.Versions)[1] = (*cfg5.Versions)[1], (*cfg5.Versions)[0]
 
 		cfg6 := cfg4
-		cfg6.Versions = slices.Clone(cfg6.Versions[1:])
+		cfg6.Versions = ptr.Ref(slices.Clone((*cfg6.Versions)[1:]))
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -143,7 +143,7 @@ func TestAccTemplateResource(t *testing.T) {
 				{
 					Config: cfg1.String(t),
 					PreConfig: func() {
-						file := fmt.Sprintf("%s/terraform.tfvars", *cfg1.Versions[0].Directory)
+						file := fmt.Sprintf("%s/terraform.tfvars", *(*cfg1.Versions)[0].Directory)
 						newFile := []byte("name = \"world2\"")
 						err := os.WriteFile(file, newFile, 0644)
 						require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestAccTemplateResource(t *testing.T) {
 				{
 					Config: cfg1.String(t),
 					PreConfig: func() {
-						file := fmt.Sprintf("%s/terraform.tfvars", *cfg1.Versions[0].Directory)
+						file := fmt.Sprintf("%s/terraform.tfvars", *(*cfg1.Versions)[0].Directory)
 						newFile := []byte("name = \"world\"")
 						err := os.WriteFile(file, newFile, 0644)
 						require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template2"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateTwo,
@@ -280,33 +280,33 @@ func TestAccTemplateResource(t *testing.T) {
 					},
 					Active: ptr.Ref(false),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[1].Name = ptr.Ref("new-name")
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
+		(*cfg2.Versions)[1].Name = ptr.Ref("new-name")
 
 		cfg3 := cfg2
-		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions[0].Name = ptr.Ref("new-name-one")
-		cfg3.Versions[1].Name = ptr.Ref("new-name-two")
-		cfg3.Versions[0], cfg3.Versions[1] = cfg3.Versions[1], cfg3.Versions[0]
+		cfg3.Versions = ptr.Ref(slices.Clone(*cfg3.Versions))
+		(*cfg3.Versions)[0].Name = ptr.Ref("new-name-one")
+		(*cfg3.Versions)[1].Name = ptr.Ref("new-name-two")
+		(*cfg3.Versions)[0], (*cfg3.Versions)[1] = (*cfg3.Versions)[1], (*cfg3.Versions)[0]
 
 		cfg4 := cfg1
-		cfg4.Versions = slices.Clone(cfg4.Versions)
-		cfg4.Versions[0].Directory = &exTemplateOne
+		cfg4.Versions = ptr.Ref(slices.Clone(*cfg4.Versions))
+		(*cfg4.Versions)[0].Directory = &exTemplateOne
 
 		cfg5 := cfg4
-		cfg5.Versions = slices.Clone(cfg5.Versions)
-		cfg5.Versions[1].Directory = &exTemplateOne
+		cfg5.Versions = ptr.Ref(slices.Clone(*cfg5.Versions))
+		(*cfg5.Versions)[1].Directory = &exTemplateOne
 
 		cfg6 := cfg5
-		cfg6.Versions = slices.Clone(cfg6.Versions)
-		cfg6.Versions[0].TerraformVariables = []testAccTemplateKeyValueConfig{
+		cfg6.Versions = ptr.Ref(slices.Clone(*cfg6.Versions))
+		(*cfg6.Versions)[0].TerraformVariables = []testAccTemplateKeyValueConfig{
 			{
 				Key:   ptr.Ref("name"),
 				Value: ptr.Ref("world2"),
@@ -386,7 +386,7 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template3"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateTwo,
@@ -398,15 +398,15 @@ func TestAccTemplateResource(t *testing.T) {
 					},
 					Active: ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[0].TerraformVariables = []testAccTemplateKeyValueConfig{
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
+		(*cfg2.Versions)[0].TerraformVariables = []testAccTemplateKeyValueConfig{
 			{
 				Key:   ptr.Ref("name"),
 				Value: ptr.Ref("world2"),
@@ -439,13 +439,13 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(false),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
@@ -473,36 +473,36 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[0].Active = ptr.Ref(false)
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
+		(*cfg2.Versions)[0].Active = ptr.Ref(false)
 
 		cfg3 := cfg2
-		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions[0].Directory = &exTemplateTwo
+		cfg3.Versions = ptr.Ref(slices.Clone(*cfg3.Versions))
+		(*cfg3.Versions)[0].Directory = &exTemplateTwo
 
 		cfg2b := cfg1
-		cfg2b.Versions = slices.Clone(cfg2b.Versions)
-		cfg2b.Versions = append(cfg2b.Versions, testAccTemplateVersionConfig{
+		cfg2b.Versions = ptr.Ref(slices.Clone(*cfg2b.Versions))
+		cfg2b.Versions = ptr.Ref(append(*cfg2b.Versions, testAccTemplateVersionConfig{
 			Directory: &exTemplateTwo,
 			Active:    ptr.Ref(false),
-		})
+		}))
 
 		cfg3b := cfg2b
-		cfg3b.Versions = slices.Clone(cfg3b.Versions)
-		cfg3b.Versions[1].Active = ptr.Ref(true)
+		cfg3b.Versions = ptr.Ref(slices.Clone(*cfg3b.Versions))
+		(*cfg3b.Versions)[1].Active = ptr.Ref(true)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -541,29 +541,29 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[0].Active = ptr.Ref(false)
-		cfg2.Versions = append(cfg2.Versions, testAccTemplateVersionConfig{
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
+		(*cfg2.Versions)[0].Active = ptr.Ref(false)
+		cfg2.Versions = ptr.Ref(append(*cfg2.Versions, testAccTemplateVersionConfig{
 			Directory: &exTemplateTwo,
 			Active:    ptr.Ref(false),
-		})
+		}))
 
 		cfg3 := cfg2
-		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions[1].Active = ptr.Ref(true)
+		cfg3.Versions = ptr.Ref(slices.Clone(*cfg3.Versions))
+		(*cfg3.Versions)[1].Active = ptr.Ref(true)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -597,26 +597,26 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				null: true,
 			},
 		}
 
 		cfg2 := cfg1
-		cfg2.Versions = slices.Clone(cfg2.Versions)
-		cfg2.Versions[0].Active = ptr.Ref(false)
-		cfg2.Versions[0].Directory = &exTemplateTwo
+		cfg2.Versions = ptr.Ref(slices.Clone(*cfg2.Versions))
+		(*cfg2.Versions)[0].Active = ptr.Ref(false)
+		(*cfg2.Versions)[0].Directory = &exTemplateTwo
 
 		cfg3 := cfg2
-		cfg3.Versions = slices.Clone(cfg3.Versions)
-		cfg3.Versions[0].Active = ptr.Ref(true)
+		cfg3.Versions = ptr.Ref(slices.Clone(*cfg3.Versions))
+		(*cfg3.Versions)[0].Active = ptr.Ref(true)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -659,12 +659,12 @@ func TestAccTemplateResource(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL:               testAccTemplateACLConfig{null: true},
 			MaxPortShareLevel: ptr.Ref("invalid"),
 		}
@@ -702,11 +702,10 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 
 	t.Run("CreateWithoutVersionsErrors", func(t *testing.T) {
 		cfg := testAccTemplateResourceConfig{
-			URL:          client.URL.String(),
-			Token:        client.SessionToken(),
-			Name:         ptr.Ref("no-versions-template"),
-			VersionsNull: true,
-			ACL:          testAccTemplateACLConfig{null: true},
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  ptr.Ref("no-versions-template"),
+			ACL:   testAccTemplateACLConfig{null: true},
 		}
 
 		resource.Test(t, resource.TestCase{
@@ -752,12 +751,12 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref(tpl.Name),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					Directory: &exTemplate,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{null: true},
 		}
 
@@ -765,8 +764,8 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 		// version active. The template already has an active version on
 		// the server; this config is just adopting it, not creating it.
 		cfgReimported := cfgManaged
-		cfgReimported.Versions = slices.Clone(cfgReimported.Versions)
-		cfgReimported.Versions[0].Active = ptr.Ref(false)
+		cfgReimported.Versions = ptr.Ref(slices.Clone(*cfgReimported.Versions))
+		(*cfgReimported.Versions)[0].Active = ptr.Ref(false)
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
@@ -809,18 +808,17 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("settings-only-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					Directory: &exTemplate,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{null: true},
 		}
 
 		cfgUnmanaged := cfgManaged
 		cfgUnmanaged.Versions = nil
-		cfgUnmanaged.VersionsNull = true
 
 		cfgUnmanagedWithNewDescription := cfgUnmanaged
 		cfgUnmanagedWithNewDescription.Description = ptr.Ref("now managed by an external pipeline")
@@ -869,7 +867,6 @@ func TestAccTemplateResourceOptionalVersions(t *testing.T) {
 			IsUnitTest:               true,
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{
-				// Terraform creates the template and its first version, as usual.
 				{
 					Config: cfgManaged.String(t),
 					Check: resource.ComposeAggregateTestCheckFunc(
@@ -950,13 +947,13 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					// Auto-generated version name
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 			ACL: testAccTemplateACLConfig{
 				GroupACL: []testAccTemplateKeyValueConfig{
 					{
@@ -1084,12 +1081,12 @@ func TestAccTemplateResourceEnterprise(t *testing.T) {
 			URL:   client.URL.String(),
 			Token: client.SessionToken(),
 			Name:  ptr.Ref("example-template"),
-			Versions: []testAccTemplateVersionConfig{
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
 				{
 					Directory: &exTemplateOne,
 					Active:    ptr.Ref(true),
 				},
-			},
+			}),
 		}
 
 		cfgOwner := baseCfg
@@ -1147,12 +1144,12 @@ func TestAccTemplateResourceBackCompat(t *testing.T) {
 		URL:   client.URL.String(),
 		Token: client.SessionToken(),
 		Name:  ptr.Ref("example-template"),
-		Versions: []testAccTemplateVersionConfig{
+		Versions: ptr.Ref([]testAccTemplateVersionConfig{
 			{
 				Directory: &exTemplateOne,
 				Active:    ptr.Ref(true),
 			},
-		},
+		}),
 		ACL: testAccTemplateACLConfig{
 			null: true,
 		},
@@ -1192,13 +1189,13 @@ func TestAccTemplateResourceAGPL(t *testing.T) {
 		URL:   client.URL.String(),
 		Token: client.SessionToken(),
 		Name:  ptr.Ref("example-template"),
-		Versions: []testAccTemplateVersionConfig{
+		Versions: ptr.Ref([]testAccTemplateVersionConfig{
 			{
 				// Auto-generated version name
 				Directory: &exTemplateOne,
 				Active:    ptr.Ref(true),
 			},
-		},
+		}),
 		AllowUserAutostart: ptr.Ref(false),
 	}
 
@@ -1541,12 +1538,11 @@ type testAccTemplateResourceConfig struct {
 	CORSBehavior                 *string
 	UseClassicParameterFlow      *bool
 
-	// VersionsNull renders `versions = null` instead of a list, regardless of
-	// the contents of Versions. Used to test that Terraform can manage a
-	// template's settings without owning its version lifecycle.
-	VersionsNull bool
-	Versions     []testAccTemplateVersionConfig
-	ACL          testAccTemplateACLConfig
+	// Versions is a pointer so that a nil value renders `versions = null`
+	// (matching AutostartRequirement above), letting tests exercise
+	// settings-only management of a template (see PLAT-288).
+	Versions *[]testAccTemplateVersionConfig
+	ACL      testAccTemplateACLConfig
 }
 
 type testAccTemplateACLConfig struct {
@@ -1624,12 +1620,9 @@ func (c testAccAutostopRequirementConfig) String(t *testing.T) string {
 	return buf.String()
 }
 
-// versionsString renders the `versions` attribute. When VersionsNull is set,
-// it renders `null` regardless of the contents of Versions, so tests can
-// exercise settings-only management of a template (see PLAT-288).
 func (c testAccTemplateResourceConfig) versionsString(t *testing.T) string {
 	t.Helper()
-	if c.VersionsNull {
+	if c.Versions == nil {
 		return "null"
 	}
 	tpl := `[
@@ -1660,7 +1653,7 @@ func (c testAccTemplateResourceConfig) versionsString(t *testing.T) string {
 	tmpl, err := template.New("versions").Funcs(funcMap).Parse(tpl)
 	require.NoError(t, err)
 
-	err = tmpl.Execute(&buf, c.Versions)
+	err = tmpl.Execute(&buf, *c.Versions)
 	require.NoError(t, err)
 
 	return buf.String()


### PR DESCRIPTION
## Why

Some teams are moving template version rollout out of Terraform and into a
custom CI pipeline that calls `coder templates push` directly — this gives
them more control over how new versions are rolled out (e.g. pushing
inactive versions for testing, activating on a separate schedule, deploying
more than once a day). They still want Terraform to manage the template's
other settings: ACL, dormancy TTLs, autostop requirements, etc.

That split wasn't possible before this change, because `versions` on
`coderd_template` was `Required` and had to contain at least one element.
Every `coderd_template` resource was therefore forced to "own" at least one
version, which caused two problems:

1. There was no way to configure the resource at all without declaring a
   version — you couldn't manage settings-only.
2. Even with a throwaway/bootstrap version as a workaround, `Read()` would
   refresh that version's `active` flag from the API on every plan. Once the
   external pipeline activated a different version, the next `terraform
   apply` — even one only touching a TTL — would see that diff and call
   `UpdateActiveTemplateVersion` to reactivate Terraform's own (now stale)
   version, silently reverting whatever the pipeline had just rolled out.

## What changed

- **`versions` is now `Optional`** (dropped `Required` and the
  `listvalidator.SizeAtLeast(1)` validator on the schema attribute). Null or
  omitted `versions` now means "Terraform does not create, update, or read
  any template version — it only manages the template's other settings."
  This mirrors the existing `acl` attribute on this same resource, where
  `null` already means "don't manage this."
- **`Create()` now explicitly requires at least one version (with exactly
  one active)** before doing anything else. This can't be relaxed away:
  Coderd's `POST /templates` API itself requires a version ID to create a
  template, so `versions` can only be optional for templates that already
  exist (created previously by Terraform, or by `terraform import`).
- **Moved the "must have an active version" check** from the `versions`
  plan modifier into `Create()`. It used to infer "this is a brand-new
  resource" from "there's no prior private state yet," but that heuristic
  breaks for a `terraform import`ed template with `versions` omitted (no
  private state is ever written for an imported resource, since `Create()`
  never runs for it) — it would have raised a false "must be active" error
  on the very first plan after import. `Create()` is unambiguous: it's only
  ever invoked by Terraform Core for a genuine create.
- **The plan modifier now short-circuits on a null/unknown `versions`
  config**, before doing any reconciliation. Without this, rebuilding the
  planned list from zero elements would have produced a non-null empty list
  (`[]`) instead of preserving `null`, quietly turning "I didn't set this"
  into "I set it to empty."
- **`Read()` and `Update()` needed no changes.** Both already iterate over
  `Versions` with a plain Go `for range`, which is a no-op on a nil/empty
  slice — so "leave version management alone, just reconcile settings" was
  already their behavior once they could ever see an empty list.

## How it works

With `versions` left `null`, `Read()` never asks Coderd which version is
active, because it only loops over versions Terraform is already tracking
(zero, in this case) — there is nothing to compare against config, so there
is no drift to react to. Whatever the external pipeline does to the
template's active version is invisible to (and left untouched by)
Terraform. `Update()` only ever pushes/activates a version when
`Versions` is non-empty, so it never touches version state either.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] New `TestAccTemplateResourceOptionalVersions` (acceptance, against a
      real Coderd via testcontainers):
  - `CreateWithoutVersionsErrors` — creating a brand-new template with no
    versions fails with a clear error
  - `SettingsOnlyManagementAfterDroppingVersions` — create with Terraform,
    drop `versions` to `null`, have an external "pipeline" push and
    activate a new version directly against the API, then have Terraform
    update a setting — verifies Terraform never touches versions and the
    pipeline's active version survives
- [x] Full pre-existing `TestAccTemplateResource` suite reran — no
      regressions
- [x] Docs regenerated via `tfplugindocs generate`

## Manual Test

In addition to the automated tests above, I ran this end-to-end against a real
local Coder deployment with the real Terraform CLI (not the acceptance-test
harness), to confirm the actual customer workflow from the linked issue.

<details>
<summary><b>Setup: build the provider, point Terraform at it, start a local Coder</b></summary>

```shell
# 1. Build and install the modified provider
cd terraform-provider-coderd
go install .
# -> installs $(go env GOPATH)/bin/terraform-provider-coderd

# 2. Point Terraform at the local build (project-scoped, doesn't touch ~/.terraformrc)
cat > /tmp/dev.tfrc <<'EOF'
provider_installation {
  dev_overrides {
    "coder/coderd" = "/Users/<you>/go/bin"
  }
  direct {}
}
EOF
export TF_CLI_CONFIG_FILE=/tmp/dev.tfrc
# With dev_overrides active, skip `terraform init` for this provider.

# 3. Start a disposable local Coder deployment
docker network create coder-manual-test
docker run -d --name coder-pg --network coder-manual-test \
  -e POSTGRES_USER=coder -e POSTGRES_PASSWORD=coder -e POSTGRES_DB=coder postgres:17
docker run -d --name coder-server --network coder-manual-test -p 3000:3000 \
  -e CODER_PG_CONNECTION_URL="postgres://coder:coder@coder-pg/coder?sslmode=disable" \
  -e CODER_ACCESS_URL="http://localhost:3000" -e CODER_ADDRESS="0.0.0.0:3000" \
  ghcr.io/coder/coder:latest
curl -sf http://localhost:3000/api/v2/buildinfo   # wait until this succeeds

# 4. Bootstrap the first user (use an isolated CODER_CONFIG_DIR, or the web UI,
#    so this doesn't clobber your own default `coder` CLI session)
export CODER_CONFIG_DIR=/tmp/coderv2-manual-test
coder login http://localhost:3000 \
  --first-user-username admin --first-user-email admin@coder.com \
  --first-user-password "SomeSecurePassword123!" --first-user-trial=false
cat "$CODER_CONFIG_DIR/session"   # session token, paste into provider "token"
```

</details>

**Scenario A — creating a *new* template with `versions` omitted still fails clearly** (Coderd requires a version to exist at all):

```hcl
resource "coderd_template" "test" {
  name = "settings-only-template"
  # no `versions` block
}
```

<details>
<summary>Output: <code>terraform apply</code></summary>

```
Plan: 1 to add, 0 to change, 0 to destroy.
coderd_template.test: Creating...
╷
│ Error: Client Error
│
│   with coderd_template.test,
│   on main.tf line 14, in resource "coderd_template" "test":
│   14: resource "coderd_template" "test" {
│
│ At least one template version (with `active = true`) is required when
│ creating a new `coderd_template` resource, since Coder templates cannot
│ exist without a version.
│ To manage an existing template without Terraform-managed versions, use
│ `terraform import` instead.
╵
```

</details>

**Scenario B — create normally, then drop `versions` to `null`** — only the `versions` attribute should change, the template and its version stay put:

<details>
<summary>Output: create with one active version, then <code>versions = null</code></summary>

```
# terraform apply (with versions = [{ directory = "...", active = true }])
Plan: 1 to add, 0 to change, 0 to destroy.
coderd_template.test: Creating...
coderd_template.test: Creation complete after 2s [id=2490ed95-d47e-45cb-b033-a265479c046b]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

# edit main.tf: versions = null, then terraform apply
  ~ resource "coderd_template" "test" {
        name                              = "settings-only-template"
      - versions                          = [
          - {
              - active         = true -> null
              - directory      = "/.../example-template" -> null
              - directory_hash = "f2a1566b..." -> null
              - id             = "50526510-8042-494a-b932-8c35639fb69c" -> null
              - name           = "gleaming_yang68" -> null
            },
        ] -> null
        # (17 unchanged attributes hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

# coder templates versions list settings-only-template
NAME             CREATED AT            CREATED BY  STATUS     ACTIVE
gleaming_yang68  2026-07-06T21:29:26Z  admin       Succeeded  Active
```

</details>

**Scenario C — the actual customer scenario: an external pipeline pushes and activates a new version while `versions` is `null`** — `terraform plan` must show *no drift*:

<details>
<summary>Contents of <code>example-template-2</code> (the "new" version the pipeline pushes)</summary>

`integration/template-test/example-template-2/main.tf`:
```hcl
variable "name" {
  type = string
}

resource "local_file" "a" {
  filename = "${path.module}/a.txt"
  content  = "hello ${var.name}"
}

output "a" {
  value = local_file.a.content
}
```

</details>

<details>
<summary>Output: <code>coder templates push --activate</code> outside Terraform, then <code>terraform plan</code></summary>

```
$ coder templates push settings-only-template -d ./example-template-2 --activate --yes
Updated version at Jul  6 14:30:25!

$ coder templates versions list settings-only-template
NAME                     CREATED AT            CREATED BY  STATUS     ACTIVE
frightening_robinson82  2026-07-06T21:30:24Z  admin       Succeeded  Active
gleaming_yang68          2026-07-06T21:29:26Z  admin       Succeeded

$ terraform plan
coderd_template.test: Refreshing state... [id=2490ed95-d47e-45cb-b033-a265479c046b]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

</details>

**Scenario D — Terraform updates a setting while `versions` is `null`** — only the setting changes, the pipeline's active version must survive untouched:

<details>
<summary>Output: <code>terraform apply</code> with a new <code>description</code>, then re-check active version</summary>

```
$ terraform apply   # description = "now managed by an external pipeline" added
  ~ resource "coderd_template" "test" {
      ~ description                       = "" -> "now managed by an external pipeline"
        id                                = "2490ed95-d47e-45cb-b033-a265479c046b"
        name                              = "settings-only-template"
        # (16 unchanged attributes hidden)
    }
Plan: 0 to add, 1 to change, 0 to destroy.
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ coder templates versions list settings-only-template
NAME                     CREATED AT            CREATED BY  STATUS     ACTIVE
frightening_robinson82  2026-07-06T21:30:24Z  admin       Succeeded  Active
gleaming_yang68          2026-07-06T21:29:26Z  admin       Succeeded
```

`frightening_robinson82` (the pipeline's version) is still `Active` — Terraform never touched it.

</details>
