### PR TITLE
fix(coderd_ai_provider): fail clearly when server drops Bedrock role_arn

### DIFF
--- a/internal/provider/ai_provider_resource.go
+++ b/internal/provider/ai_provider_resource.go
@@ -401,6 +401,10 @@ func (r *AIProviderResource) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create AI provider, got error: %s", err))
 		return
 	}
+	checkBedrockRoleARNDropped(config, provider, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	state := plan.stateFromProvider(provider)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -470,6 +474,10 @@ func (r *AIProviderResource) Update(ctx context.Context, req resource.UpdateRequ
 	provider, err := r.data.Client.UpdateAIProvider(ctx, state.ID.ValueString(), patch)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update AI provider, got error: %s", err))
+		return
+	}
+	checkBedrockRoleARNDropped(config, provider, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	updated := plan.stateFromProvider(provider)
@@ -646,6 +654,25 @@ func (m AIProviderResourceModel) stateFromProvider(provider codersdk.AIProvider)
 		}
 	}
 	return out
+}
+
+// A Coder server older than v2.35.0 drops the unknown role_arn JSON key
+// (omitempty), so a configured value round-trips to null and surfaces as a
+// cryptic "inconsistent values for sensitive attribute" error. Fail loudly
+// instead. (#387)
+func checkBedrockRoleARNDropped(config AIProviderResourceModel, provider codersdk.AIProvider, diags *diag.Diagnostics) {
+	b := config.bedrock()
+	if b == nil || b.RoleARN.IsNull() || b.RoleARN.IsUnknown() || b.RoleARN.ValueString() == "" {
+		return
+	}
+	if provider.Settings.Bedrock != nil && provider.Settings.Bedrock.RoleARN != "" {
+		return
+	}
+	diags.AddAttributeError(
+		path.Root("settings").AtName("bedrock").AtName("role_arn"),
+		"Bedrock role_arn not supported by this Coder deployment",
+		"The Coder server accepted the request but did not persist `role_arn`, which means it predates Bedrock STS assume-role support. Upgrade to Coder v2.35.0 or later, or remove `role_arn`.",
+	)
 }
 
 func (m AIProviderResourceModel) bedrock() *AIProviderBedrockSettingsModel {

--- a/internal/provider/ai_provider_resource.go
+++ b/internal/provider/ai_provider_resource.go
@@ -658,8 +658,8 @@ func (m AIProviderResourceModel) stateFromProvider(provider codersdk.AIProvider)
 
 // A Coder server older than v2.35.0 drops the unknown role_arn JSON key
 // (omitempty), so a configured value round-trips to null and surfaces as a
-// cryptic "inconsistent values for sensitive attribute" error. Fail loudly
-// instead. (#387)
+// cryptic "inconsistent values for sensitive attribute" error (#387). Fail
+// loudly instead.
 func checkBedrockRoleARNDropped(config AIProviderResourceModel, provider codersdk.AIProvider, diags *diag.Diagnostics) {
 	b := config.bedrock()
 	if b == nil || b.RoleARN.IsNull() || b.RoleARN.IsUnknown() || b.RoleARN.ValueString() == "" {

--- a/internal/provider/ai_provider_resource_test.go
+++ b/internal/provider/ai_provider_resource_test.go
@@ -872,3 +872,69 @@ func TestAIProviderStateFromProviderMapsEmptyBedrockStringsToNull(t *testing.T) 
 	require.True(t, b.SmallFastModel.IsNull())
 	require.True(t, b.RoleARN.IsNull())
 }
+
+func TestAIProviderCheckBedrockRoleARNDropped(t *testing.T) {
+	t.Parallel()
+
+	const roleARN = "arn:aws:iam::123456789012:role/bedrock-access"
+	configWithRoleARN := AIProviderResourceModel{
+		Settings: &AIProviderSettingsModel{Bedrock: &AIProviderBedrockSettingsModel{
+			RoleARN: types.StringValue(roleARN),
+		}},
+	}
+
+	for name, tc := range map[string]struct {
+		config    AIProviderResourceModel
+		response  codersdk.AIProvider
+		wantError bool
+	}{
+		"role_arn stripped by old server": {
+			config: configWithRoleARN,
+			response: codersdk.AIProvider{Settings: codersdk.AIProviderSettings{
+				Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+			}},
+			wantError: true,
+		},
+		"bedrock settings dropped entirely": {
+			config:    configWithRoleARN,
+			response:  codersdk.AIProvider{},
+			wantError: true,
+		},
+		"role_arn persisted": {
+			config: configWithRoleARN,
+			response: codersdk.AIProvider{Settings: codersdk.AIProviderSettings{
+				Bedrock: &codersdk.AIProviderBedrockSettings{RoleARN: roleARN},
+			}},
+			wantError: false,
+		},
+		"role_arn not configured (access-key auth)": {
+			config: AIProviderResourceModel{
+				Settings: &AIProviderSettingsModel{Bedrock: &AIProviderBedrockSettingsModel{
+					RoleARN: types.StringNull(),
+				}},
+			},
+			response: codersdk.AIProvider{Settings: codersdk.AIProviderSettings{
+				Bedrock: &codersdk.AIProviderBedrockSettings{Region: "us-east-1"},
+			}},
+			wantError: false,
+		},
+		"no bedrock settings": {
+			config:    AIProviderResourceModel{},
+			response:  codersdk.AIProvider{},
+			wantError: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+			checkBedrockRoleARNDropped(tc.config, tc.response, &diags)
+			if tc.wantError {
+				require.True(t, diags.HasError(), "expected a diagnostic")
+				require.Contains(t, diags.Errors()[0].Summary(), "Bedrock role_arn not supported by this Coder deployment")
+			} else {
+				require.False(t, diags.HasError(), diags.Errors())
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `role_arn` schema docs already note it requires Coder v2.35.0+, but nothing enforced it: on an older server the field is silently dropped (`omitempty`), round-trips to null, and apply fails with the cryptic "inconsistent values for sensitive attribute" error.

This adds an explicit check in `Create`/`Update` — if a requested `role_arn` comes back empty, we fail with a clear diagnostic telling the user to upgrade or remove it.

Closes coder/terraform-provider-coderd#387
Closes ENG-3027