### PR TITLE
fix(coderd_template): validate ACL roles

### DIFF
--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -86,7 +86,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
-- `role` (String)
+- `role` (String) Role assigned to the user or group. Valid roles are `admin` and `use`.
 
 
 <a id="nestedatt--acl--users"></a>
@@ -95,7 +95,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
-- `role` (String)
+- `role` (String) Role assigned to the user or group. Valid roles are `admin` and `use`.
 
 
 

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -104,7 +104,7 @@ Required:
 Required:
 
 - `id` (String)
-- `role` (String)
+- `role` (String) Role assigned to the user or group. Valid roles are `admin` and `use`.
 
 
 <a id="nestedatt--acl--users"></a>
@@ -113,7 +113,7 @@ Required:
 Required:
 
 - `id` (String)
-- `role` (String)
+- `role` (String) Role assigned to the user or group. Valid roles are `admin` and `use`.
 
 
 

--- a/internal/provider/template_data_source.go
+++ b/internal/provider/template_data_source.go
@@ -353,7 +353,8 @@ var computedPermissionAttribute = schema.SetNestedAttribute{
 				Computed: true,
 			},
 			"role": schema.StringAttribute{
-				Computed: true,
+				MarkdownDescription: "Role assigned to the user or group. Valid roles are `admin` and `use`.",
+				Computed:            true,
 			},
 		},
 	},

--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -258,7 +258,11 @@ var permissionAttribute = schema.SetNestedAttribute{
 				Required: true,
 			},
 			"role": schema.StringAttribute{
-				Required: true,
+				MarkdownDescription: "Role assigned to the user or group. Valid roles are `admin` and `use`.",
+				Required:            true,
+				Validators: []validator.String{
+					templateACLRoleValidator,
+				},
 			},
 		},
 	},
@@ -1177,6 +1181,11 @@ var _ planmodifier.List = &versionsPlanModifier{}
 
 var weekValidator = setvalidator.ValueStringsAre(
 	stringvalidator.OneOf("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"),
+)
+
+var templateACLRoleValidator = stringvalidator.OneOf(
+	string(codersdk.TemplateRoleAdmin),
+	string(codersdk.TemplateRoleUse),
 )
 
 func uploadDirectory(ctx context.Context, client *codersdk.Client, logger slog.Logger, directory string) (*codersdk.UploadResponse, error) {

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -35,6 +35,30 @@ func mustVariablesToSet(vars []Variable) types.Set {
 	return s
 }
 
+func TestTemplateACLRoleValidator(t *testing.T) {
+	t.Parallel()
+
+	for _, role := range []string{"admin", "use"} {
+		t.Run(role, func(t *testing.T) {
+			t.Parallel()
+			var resp validator.StringResponse
+			templateACLRoleValidator.ValidateString(context.Background(), validator.StringRequest{
+				ConfigValue: types.StringValue(role),
+			}, &resp)
+			require.False(t, resp.Diagnostics.HasError())
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		var resp validator.StringResponse
+		templateACLRoleValidator.ValidateString(context.Background(), validator.StringRequest{
+			ConfigValue: types.StringValue("owner"),
+		}, &resp)
+		require.True(t, resp.Diagnostics.HasError())
+	})
+}
+
 func TestAccTemplateResource(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {
@@ -677,6 +701,40 @@ func TestAccTemplateResource(t *testing.T) {
 				{
 					Config:      cfg1.String(t),
 					ExpectError: regexp.MustCompile(`value must be one of`),
+				},
+			},
+		})
+	})
+
+	t.Run("InvalidACLRole", func(t *testing.T) {
+		cfg1 := testAccTemplateResourceConfig{
+			URL:   client.URL.String(),
+			Token: client.SessionToken(),
+			Name:  ptr.Ref("example-template"),
+			Versions: ptr.Ref([]testAccTemplateVersionConfig{
+				{
+					Directory: &exTemplateOne,
+					Active:    ptr.Ref(true),
+				},
+			}),
+			ACL: testAccTemplateACLConfig{
+				GroupACL: []testAccTemplateKeyValueConfig{
+					{
+						Key:   ptr.Ref(firstUser.OrganizationIDs[0].String()),
+						Value: ptr.Ref("owner"),
+					},
+				},
+			},
+		}
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			IsUnitTest:               true,
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config:      cfg1.String(t),
+					ExpectError: regexp.MustCompile(`value must be one of: \["admin" "use"\]`),
 				},
 			},
 		})

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -35,27 +35,39 @@ func mustVariablesToSet(vars []Variable) types.Set {
 	return s
 }
 
-func TestTemplateACLRoleValidator(t *testing.T) {
+func TestTemplateResourceACLRoleSchemaValidation(t *testing.T) {
 	t.Parallel()
 
-	for _, role := range []string{"admin", "use"} {
-		t.Run(role, func(t *testing.T) {
-			t.Parallel()
-			var resp validator.StringResponse
-			templateACLRoleValidator.ValidateString(context.Background(), validator.StringRequest{
-				ConfigValue: types.StringValue(role),
-			}, &resp)
-			require.False(t, resp.Diagnostics.HasError())
-		})
+	directory := "."
+	cfg := testAccTemplateResourceConfig{
+		URL:   "http://127.0.0.1",
+		Token: "test-token",
+		Name:  ptr.Ref("example-template"),
+		Versions: ptr.Ref([]testAccTemplateVersionConfig{
+			{
+				Directory: &directory,
+				Active:    ptr.Ref(true),
+			},
+		}),
+		ACL: testAccTemplateACLConfig{
+			GroupACL: []testAccTemplateKeyValueConfig{
+				{
+					Key:   ptr.Ref("00000000-0000-0000-0000-000000000000"),
+					Value: ptr.Ref("owner"),
+				},
+			},
+		},
 	}
 
-	t.Run("invalid", func(t *testing.T) {
-		t.Parallel()
-		var resp validator.StringResponse
-		templateACLRoleValidator.ValidateString(context.Background(), validator.StringRequest{
-			ConfigValue: types.StringValue("owner"),
-		}, &resp)
-		require.True(t, resp.Diagnostics.HasError())
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg.String(t),
+				ExpectError: regexp.MustCompile(`value must be one of`),
+			},
+		},
 	})
 }
 
@@ -701,40 +713,6 @@ func TestAccTemplateResource(t *testing.T) {
 				{
 					Config:      cfg1.String(t),
 					ExpectError: regexp.MustCompile(`value must be one of`),
-				},
-			},
-		})
-	})
-
-	t.Run("InvalidACLRole", func(t *testing.T) {
-		cfg1 := testAccTemplateResourceConfig{
-			URL:   client.URL.String(),
-			Token: client.SessionToken(),
-			Name:  ptr.Ref("example-template"),
-			Versions: ptr.Ref([]testAccTemplateVersionConfig{
-				{
-					Directory: &exTemplateOne,
-					Active:    ptr.Ref(true),
-				},
-			}),
-			ACL: testAccTemplateACLConfig{
-				GroupACL: []testAccTemplateKeyValueConfig{
-					{
-						Key:   ptr.Ref(firstUser.OrganizationIDs[0].String()),
-						Value: ptr.Ref("owner"),
-					},
-				},
-			},
-		}
-
-		resource.Test(t, resource.TestCase{
-			PreCheck:                 func() { testAccPreCheck(t) },
-			IsUnitTest:               true,
-			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-			Steps: []resource.TestStep{
-				{
-					Config:      cfg1.String(t),
-					ExpectError: regexp.MustCompile(`value must be one of: \["admin" "use"\]`),
 				},
 			},
 		})


### PR DESCRIPTION
This adds plan-time validation for coderd_template ACL roles so Terraform rejects unsupported values before apply. Valid roles are admin and use, matching the Coder SDK constants. It also updates generated template docs to describe the accepted ACL role values.