### PR TITLE
fix(coderd_template): validate description length at plan time

### DIFF
--- a/internal/provider/template_resource.go
+++ b/internal/provider/template_resource.go
@@ -323,6 +323,11 @@ func (r *TemplateResource) Schema(ctx context.Context, req resource.SchemaReques
 				Computed:            true,
 				Optional:            true,
 				Default:             stringdefault.StaticString(""),
+				Validators: []validator.String{
+					// codersdk.CreateTemplateRequest.Description is `validate:"lt=128"`,
+					// which go-playground measures in runes, not bytes.
+					stringvalidator.UTF8LengthAtMost(127),
+				},
 			},
 			"organization_id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the organization. Defaults to the provider's default organization",

--- a/internal/provider/template_resource_test.go
+++ b/internal/provider/template_resource_test.go
@@ -71,6 +71,38 @@ func TestTemplateResourceACLRoleSchemaValidation(t *testing.T) {
 	})
 }
 
+func TestTemplateResourceDescriptionSchemaValidation(t *testing.T) {
+	t.Parallel()
+
+	directory := "."
+	cfg := testAccTemplateResourceConfig{
+		URL:         "http://127.0.0.1",
+		Token:       "test-token",
+		Name:        ptr.Ref("example-template"),
+		Description: ptr.Ref(strings.Repeat("a", 128)),
+		Versions: ptr.Ref([]testAccTemplateVersionConfig{
+			{
+				Directory: &directory,
+				Active:    ptr.Ref(true),
+			},
+		}),
+		ACL: testAccTemplateACLConfig{
+			null: true,
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cfg.String(t),
+				ExpectError: regexp.MustCompile(`must be at most 127`),
+			},
+		},
+	})
+}
+
 func TestAccTemplateResource(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("TF_ACC") == "" {


### PR DESCRIPTION
## Problem

`coderd_template.description` has no validator in the schema, but the Coder API bounds it: `codersdk.CreateTemplateRequest.Description` carries a `lt=128` validate tag. An over-long description plans clean and only fails when `Create`/`Update` reaches the API:

```
Error: Failed to create template

POST /api/v2/organizations/<id>/templates: unexpected status code 400: Invalid input.
description: must be less than 128
```

Repro — plans without complaint, fails at apply:

```hcl
resource "coderd_template" "example" {
  name        = "example"
  description = "<128 or more characters>"
  versions    = [{ directory = "./template", active = true }]
}
```

The cost is the usual one for apply-time failures: by the time this fires Terraform has already started applying, so anything sequenced before the template is created while the template is not, leaving a partial apply to clean up. It is also easy to drift into unknowingly, since a description sitting in the low 120s is fine until someone rewords it.

## Fix

Add `stringvalidator.UTF8LengthAtMost(127)` to the attribute, so it fails during validate/plan instead. This follows the same pattern already used for `name` and `display_name`, which validate via `codersdkvalidator.Name()` / `DisplayName()`; `description` was the remaining unbounded field of the three.

On the exact bound: go-playground evaluates `lt` on a string with `utf8.RuneCountInString`, so the real limit is 127 **runes**, not the 128 **bytes** the field's doc comment states. `UTF8LengthAtMost` counts UTF-8 characters and so matches the server's counting exactly; `LengthAtMost` would have been byte-based and wrongly rejected a 127-character description containing multi-byte characters.

There is no `codersdk` helper for this rule (unlike `NameValid`/`DisplayNameValid`), so the bound is expressed with the built-in validator and a comment pointing back at the tag it mirrors. Happy to add a `codersdkvalidator.Description()` wrapper instead if you would rather keep every template field going through that package.

No generated-docs change: `tfplugindocs` does not render validators, and the attribute's `MarkdownDescription` is untouched.
