### PR TITLE
chore: auto-assign PR author as assignee

### DIFF
--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -1,0 +1,18 @@
+# Filtering pull requests is much easier when we can reliably guarantee
+# that the "Assignee" field is populated.
+name: PR Auto Assign
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  assign-author:
+    permissions:
+      pull-requests: write
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-4' || 'ubuntu-latest' }}
+    steps:
+      - name: Assign author
+        uses: toshimaru/auto-author-assign@3e19bfc990cb1cf0589dce95e9f75289bb1e22de # v3.0.3


### PR DESCRIPTION
Filtering pull requests is much easier when the "Assignee" field is reliably populated. This adds the same `PR Auto Assign` workflow already used in [coder/coder](https://github.com/coder/coder/blob/main/.github/workflows/pr-auto-assign.yaml) and [coder/vscode-coder](https://github.com/coder/vscode-coder/blob/main/.github/workflows/pr-auto-assign.yaml), so newly opened PRs get their author set as assignee automatically.

Differences from the upstream copies:

- `runs-on` uses this repo's existing Depot conditional (`depot-ubuntu-22.04-4` for the `coder` org, `ubuntu-latest` otherwise) to match `test.yml` and `release.yml`.
- The `step-security/harden-runner` step and `zizmor` pragma from coder/coder are omitted: neither tool is used in this repo, and harden-runner's egress monitoring doesn't apply to Depot runners.