### PR TITLE
feat(fwprovider): export the provider implementation for embedding

### DIFF
--- a/fwprovider/fwprovider.go
+++ b/fwprovider/fwprovider.go
@@ -1,0 +1,22 @@
+// Package fwprovider exposes the coderd Terraform provider implementation to
+// other Go programs that embed it instead of running it as a plugin binary.
+//
+// The implementation lives in internal/provider, which the Go toolchain keeps
+// unimportable from outside this module. Embedders need a provider.Provider
+// value so they can read the schema and drive CRUD in-process; this package
+// hands them one without widening the rest of the internal API.
+package fwprovider
+
+import (
+	tfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+
+	"github.com/coder/terraform-provider-coderd/internal/provider"
+)
+
+// New returns a factory for the coderd provider implementation. The signature
+// matches what providerserver.Serve expects, so embedders can either serve it
+// as a plugin or call the factory directly to get an instance. version is what
+// the provider reports from its Metadata method.
+func New(version string) func() tfprovider.Provider {
+	return provider.New(version)
+}

--- a/fwprovider/fwprovider_test.go
+++ b/fwprovider/fwprovider_test.go
@@ -1,0 +1,29 @@
+package fwprovider_test
+
+import (
+	"context"
+	"testing"
+
+	tfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/terraform-provider-coderd/fwprovider"
+)
+
+// TestNew asserts that the exported factory yields the same provider main.go
+// serves, so embedders see the full set of resources and data sources.
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := fwprovider.New("test")()
+	require.NotNil(t, p)
+
+	var resp tfprovider.MetadataResponse
+	p.Metadata(ctx, tfprovider.MetadataRequest{}, &resp)
+	require.Equal(t, "coderd", resp.TypeName)
+	require.Equal(t, "test", resp.Version)
+
+	require.NotEmpty(t, p.Resources(ctx))
+	require.NotEmpty(t, p.DataSources(ctx))
+}


### PR DESCRIPTION
Adds a public `fwprovider` package that hands out the provider implementation, so Go programs can embed the provider in-process instead of running it as a plugin binary.

## Motivation

In #354 I asked for a Crossplane provider for Coder. Crossplane's [Upjet](https://github.com/crossplane/upjet) generates one directly from a Terraform provider's schema, and it can drive that provider two ways:

- **Terraform CLI mode.** Upjet bundles the `terraform` binary and the provider binary into its controller image, then runs `terraform` against a workspace per managed resource, which in turn launches the provider plugin. It works against any provider and needs no cooperation from upstream.
- **In-process mode.** Upjet calls the provider's `provider.Provider` implementation directly through its plugin-framework client. No `terraform` binary, no provider binary, no subprocess per reconcile.

In-process mode needs an importable `provider.Provider`. `internal/provider` is unimportable outside this module, so today the only route is to fork this repo and add the export in the fork. That is exactly what Upbound does for the providers that keep theirs internal — [`terraform-provider-aws/xpprovider`](https://github.com/upbound/terraform-provider-aws) and [`terraform-provider-azurerm/xpprovider`](https://github.com/upbound/terraform-provider-azurerm), both wired in through a `replace` directive. Providers that expose theirs upstream need no fork at all: `terraform-provider-google` has [`google/fwprovider`](https://github.com/hashicorp/terraform-provider-google/tree/main/google/fwprovider), `terraform-provider-keycloak` has [`provider`](https://github.com/keycloak/terraform-provider-keycloak/tree/master/provider).

I would rather not maintain a fork of this repo that has to be re-synced on every release, and I doubt you want one circulating either.

## What changed

A single public package delegating to the existing constructor:

```go
func New(version string) func() tfprovider.Provider {
	return provider.New(version)
}
```

Returning the factory rather than an instance keeps the signature identical to `provider.New`, so it still drops straight into `providerserver.Serve`; embedders call it to get an instance.

Kept deliberately small:

- No new dependencies — `terraform-plugin-framework` is already required.
- No behaviour change and no second code path. It is a one-line delegation, so it cannot drift, and a signature change to `provider.New` breaks the build here too.
- `internal/` stays internal. This exports the provider surface only, not resource implementations, `codersdk` plumbing, or helpers.
- `main.go` is untouched.
- A test asserts the factory yields the provider `main.go` serves, with `TypeName`, version, resources and data sources all wired.

I named it `fwprovider` after the `terraform-provider-google` precedent rather than Upbound's Crossplane-specific `xpprovider`, on the grounds that this is an export you own rather than one living in a downstream fork. Happy to rename it, relocate it, or narrow the signature.

## Context

I have built an [Upjet-based Crossplane provider](https://github.com/axiansinfoma/crossplane-provider-coderd) covering all 15 resources, exposing both cluster-scoped and namespaced Crossplane v2 APIs, with a scheduled job that regenerates and opens a PR when a release lands here. It runs in Terraform CLI mode today, because that is the only mode available without forking this repo.

I took the liberty of starting the implementation rather than just filing the request, so there is something concrete to react to. If you would like the Crossplane provider itself to live under the Coder org, I am happy to donate it; equally happy to keep maintaining it out-of-tree if you would rather not adopt another repo. Either way this export stands on its own for anyone embedding the provider.

Refs #354
